### PR TITLE
hoon-school/E-types: remove erroneous triple-tic

### DIFF
--- a/content/guides/core/hoon-school/E-types.md
+++ b/content/guides/core/hoon-school/E-types.md
@@ -115,7 +115,6 @@ Here's a non-exhaustive list of auras, along with examples of corresponding lite
 | `@uv`  | unsigned base32              | `0v1df64.49beg` |
 | `@uw`  | unsigned base64              | `0wbnC.8haTg` |
 | `@ux`  | unsigned hexadecimal         | `0x5f5.e138` |
-```
 
 Some of these auras nest under others.  For example, `@u` is for all unsigned auras.  But there are other, more specific auras; `@ub` for unsigned binary numbers, `@ux` for unsigned hexadecimal numbers, etc.  (For a more complete list of auras, see [Auras](/reference/hoon/auras).)
 


### PR DESCRIPTION
Chart does not need to be closed with triple backtick, and the typo leads to some weirdness where the prose following the chart is merged into the subsequent code block.