### PR TITLE
Glossary fix

### DIFF
--- a/content/guides/core/app-school/3-imports-and-aliases.md
+++ b/content/guides/core/app-school/3-imports-and-aliases.md
@@ -218,7 +218,7 @@ we can try out `dbug`. To start it, run the following in the dojo:
 ```
 
 For details of using the `|rein` generator, see the [Dojo
-Tools](/using/os/dojo-tools#rein) documentation.
+Tools](https://urbit.org/using/os/dojo-tools#rein) documentation.
 
 Now our agent should be running, so let's try out `dbug`. In the dojo, let's try
 poking our agent with the `+dbug` generator:

--- a/content/guides/core/app-school/intro.md
+++ b/content/guides/core/app-school/intro.md
@@ -35,7 +35,7 @@ interface.
 
 On the other hand, an agent is also a lot like what many systems call a
 "service". An agent is permanent and addressable -- a running program can talk
-to an agent just by naming it. An agent can perform [IO](/blog/io-in-hoon), unlike most databases.
+to an agent just by naming it. An agent can perform [IO](https://urbit.org/blog/io-in-hoon), unlike most databases.
 This is a critical part of an agent: it performs IO along the same transaction
 boundaries as changes to its state, so if an effect happens, you know that the
 associated state change has happened.

--- a/content/reference/arvo/clay/clay.md
+++ b/content/reference/arvo/clay/clay.md
@@ -22,7 +22,7 @@ foreign ships.
 
 ### User documentation
 
-[Filesystem](/using/os/filesystem)
+[Filesystem](https://urbit.org/using/os/filesystem)
 
 How to interact with the Clay filesystem via Dojo. This includes basics such as
 mounting to Unix, changing directory, merging, and listing files.

--- a/content/reference/arvo/concepts/_index.md
+++ b/content/reference/arvo/concepts/_index.md
@@ -7,7 +7,7 @@ insert_anchor_links = "right"
 
 Other concepts related to the way Arvo works.
 
-## [Scries](/reference/arvo/concepts/scries)
+## [Scries](/reference/arvo/concepts/scry)
 
 Details of performing scries.
 

--- a/content/reference/azimuth/azimuth-eth.md
+++ b/content/reference/azimuth/azimuth-eth.md
@@ -103,7 +103,7 @@ in the following `struct`:
 ## `Deed`s {% #deeds %}
 
 A `Deed` says which Ethereum address owns a given `Point` as well as several
-[proxies](/using/id/proxies) for that `Point`.
+[proxies](https://urbit.org/using/id/proxies) for that `Point`.
 
 ```solidity
 struct Deed

--- a/content/reference/azimuth/azimuth.md
+++ b/content/reference/azimuth/azimuth.md
@@ -98,7 +98,7 @@ blockchains. However, anybody can run a roller, and even using your own ship as
 a roller to submit single transactions results in significant savings.
 
 A casual overview of the naive rollups system can be found on the
-[blog](/blog/rollups). Developers are encouraged to read our Layer 2
+[blog](https://urbit.org/blog/rollups). Developers are encouraged to read our Layer 2
 documentation, starting with the [Layer 2 Overview](/reference/azimuth/l2/layer2).
 
 ## Other resources {% #other %}

--- a/content/reference/azimuth/ecliptic.md
+++ b/content/reference/azimuth/ecliptic.md
@@ -36,7 +36,7 @@ detection.
 There are currently [28 functions](#write) which may be called to write to
 the Ecliptic, and [17 functions](#read) to read data from the Ecliptic. Many of these
 have a corresponding [layer 2 action](/reference/azimuth/l2/l2-actions), and/or can be
-performed using [Bridge](/using/id/using-bridge). We note these facts where
+performed using [Bridge](https://urbit.org/using/id/using-bridge). We note these facts where
 applicable.
 
 ## Write functions {% #write %}
@@ -101,7 +101,7 @@ Corresponds to the layer 2 `%spawn` action.
 
 Transfer `_point` to `_target`, clearing all permissions data and keys if
 `_reset` is true. `_reset` set to makes this transaction a
-[breach](/using/id/guide-to-resets), and thus this action increments the
+[breach](https://urbit.org/using/id/guide-to-resets), and thus this action increments the
 [`continuityNumber`](/reference/azimuth/azimuth-eth#points) of `_point`, and usually
 the `keyRevisionNumber` as well (see [Life and
 Rift](/reference/azimuth/life-and-rift)).
@@ -196,7 +196,7 @@ action, so a layer 1 detach must be done
 ### Proxy management {% #proxies %}
 
 These functions are used to manage the various
-[proxies](/using/id/proxies). All of these actions may be performed from Bridge.
+[proxies](https://urbit.org/using/id/proxies). All of these actions may be performed from Bridge.
 
 #### `setManagementProxy`
 

--- a/content/reference/azimuth/hd-wallet.md
+++ b/content/reference/azimuth/hd-wallet.md
@@ -41,7 +41,7 @@ smart-contracts.
 ### Proxies
 
 Each permanent Urbit ID can designate one or more
-[proxies](/using/id/proxies), which are Ethereum addresses capable of a
+[proxies](https://urbit.org/using/id/proxies), which are Ethereum addresses capable of a
 limited subset of Urbit ID transactions, such as spawning planets or rotating
 keys. The HD wallet automatically generates additional addresses utilized as
 proxies according to what is appropriate for your Urbit ID.
@@ -111,7 +111,7 @@ wallet address you generated on your hardware wallet for ownership.
 Next, login to Bridge using your hardware wallet. While Bridge supports Trezor
 and Ledger natively, this may require using Metamask as an intermediary anyways,
 depending on which firmware you are running. Then [accept the
-transfer](/using/id/using-bridge#accept-your-transfer). Your Azimuth point is
+transfer](https://urbit.org/using/id/using-bridge#accept-your-transfer). Your Azimuth point is
 now stored on your hardware wallet.
 
 To finish the process, use Bridge to set your management, voting, and spawn
@@ -126,7 +126,7 @@ address live on a "cold" wallet that never touches an internet-connected
 computer, and the various proxies on a "hot" wallet that is permitted to connect
 to internet-connected devices. This could be accomplished with multiple hardware
 wallets, a combination of paper and hardware wallet, a hardware cold wallet and
-Metamask hot wallet, etc. See the [User Manual](/using/id/hd-wallet) for
+Metamask hot wallet, etc. See the [User Manual](https://urbit.org/using/id/hd-wallet) for
 concrete suggestions on security practices.
 
 One tool useful for this setup is `claz`, located at `app/claz.hoon`. `claz` is

--- a/content/reference/azimuth/l2/layer2.md
+++ b/content/reference/azimuth/l2/layer2.md
@@ -17,7 +17,7 @@ to either transfer their ship to layer 2 or perform layer 2 actions. This is a
 functionality of [Bridge](https://bridge.urbit.org) for which documentation will
 soon be available. For a casual overview of the
 rationale and functionality of layer 2, please see this [blog
-post](/blog/rollups). For more information on how Azimuth works more generally,
+post](https://urbit.org/blog/rollups). For more information on how Azimuth works more generally,
 including interactions with Bridge and Ethereum, see the page on [Azimuth data flow](/reference/azimuth/flow).
 
 This page is also not where to find instruction on how to run your own

--- a/content/reference/azimuth/life-and-rift.md
+++ b/content/reference/azimuth/life-and-rift.md
@@ -6,7 +6,7 @@ weight = 8
 Associated to every Azimuth point are two non-negative integers known as _life_
 and _rift_. This numbering system partition messages according to the quantity
 of networking key changes and quantity of
-[breaches](/using/id/guide-to-resets), respectively. This is explained in
+[breaches](https://urbit.org/using/id/guide-to-resets), respectively. This is explained in
 more detail below. These values are utilized by [Ames](/reference/arvo/ames/ames)
 and [Jael](/reference/arvo/jael/jael-api) to ensure that communication between
 ships is always done with the most recent set of networking keys, and that

--- a/content/reference/glossary/ames.md
+++ b/content/reference/glossary/ames.md
@@ -15,6 +15,6 @@ what OTA updates are capable of doing. These events are called [factory resets](
 ### Further Reading
 
 - [The Ames tutorial](/reference/arvo/ames/ames): An in-depth technical guide to the Ames protocol.
-- [A Guide to Factory Reset](/using/id/guide-to-resets): Instructions on
+- [A Guide to Factory Reset](https://urbit.org/using/id/guide-to-resets): Instructions on
   performing factory resets.
-- [Ship Troubleshooting](/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.
+- [Ship Troubleshooting](https://urbit.org/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.

--- a/content/reference/glossary/bridge.md
+++ b/content/reference/glossary/bridge.md
@@ -27,5 +27,5 @@ This function allows you to view the public information of any Urbit identity, s
 ### Further Reading
 
 - [bridge.urbit.org](https://bridge.urbit.org/): The Bridge website.
-- [Using Bridge](/using/id/using-bridge): A guide to starting out with Bridge.
+- [Using Bridge](https://urbit.org/using/id/using-bridge): A guide to starting out with Bridge.
 - [The Azimuth concepts page](/reference/azimuth/advanced-azimuth-tools): A more in-depth explanation of our identity layer.

--- a/content/reference/glossary/chat.md
+++ b/content/reference/glossary/chat.md
@@ -27,5 +27,5 @@ There are two "kinds" of chats:
 ### Further Reading
 
 - [Landscape](/reference/glossary/landscape) includes a web interface for using Chat.
-- [Messaging guide](/using/os/messaging): A guide to
+- [Messaging guide](https://urbit.org/using/os/messaging): A guide to
   using Chat from the command line.

--- a/content/reference/glossary/clay.md
+++ b/content/reference/glossary/clay.md
@@ -13,5 +13,5 @@ Clay is located at `/base/sys/vane/clay.hoon` within Arvo.
 
 ### Further Reading
 
-- [Using Your Ship](/using/os/filesystem): A user guide that includes instructions on using Clay.
+- [Using Your Ship](https://urbit.org/using/os/filesystem): A user guide that includes instructions on using Clay.
 - [The Clay tutorial](/reference/arvo/clay/clay): A technical guide to the Clay vane.

--- a/content/reference/glossary/desk.md
+++ b/content/reference/glossary/desk.md
@@ -11,4 +11,4 @@ Traditionally a ship has at least a `%base` desk, and typically `%garden` and `%
 
 ### Further Reading
 
-- [Using Your Ship](/using/os/filesystem): A user guide that includes instructions for using desks.
+- [Using Your Ship](https://urbit.org/using/os/filesystem): A user guide that includes instructions for using desks.

--- a/content/reference/glossary/hoon.md
+++ b/content/reference/glossary/hoon.md
@@ -10,4 +10,4 @@ The Hoon source file is located in `/base/sys/hoon.hoon` within your Urbit.
 ### Further Reading
 
 - [Hoon School](/guides/core/hoon-school/): Our guide to learning the Hoon programming language.
-- [Why Hoon?](/blog/why-hoon): A blog post that explains why Urbit uses its own programming language.
+- [Why Hoon?](https://urbit.org/blog/why-hoon): A blog post that explains why Urbit uses its own programming language.

--- a/content/reference/glossary/moon.md
+++ b/content/reference/glossary/moon.md
@@ -27,8 +27,8 @@ their parent planet.
 
 ### Further Reading
 
-- [Using Your Ship](/using/os/getting-started#moons): The "Moons" section contains instructions for creating and managing moons.
+- [Using Your Ship](https://urbit.org/using/os/getting-started#moons): The "Moons" section contains instructions for creating and managing moons.
 
-- [Lunar Urbit and the Internet of Things](/blog/iot): Blog post on the
+- [Lunar Urbit and the Internet of Things](https://urbit.org/blog/iot): Blog post on the
   past, present, and future of moons
 

--- a/content/reference/glossary/pier.md
+++ b/content/reference/glossary/pier.md
@@ -22,6 +22,6 @@ possible.
 ### Further Reading
 
 - [Event Log](/reference/glossary/eventlog): The main important content of the pier directory.
-- [Guide to Factory Resets](/using/id/guide-to-resets): Instructions on
+- [Guide to Factory Resets](https://urbit.org/using/id/guide-to-resets): Instructions on
   performing a factory reset.
-- [Ship Troubleshooting](/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.
+- [Ship Troubleshooting](https://urbit.org/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.

--- a/content/reference/glossary/reset.md
+++ b/content/reference/glossary/reset.md
@@ -26,6 +26,6 @@ used in some places. The notion is identical, only the name differs.
 
 ### Further Reading
 
-- [Guide to Factory Resets](/using/id/guide-to-resets): A more in-depth
+- [Guide to Factory Resets](https://urbit.org/using/id/guide-to-resets): A more in-depth
   explanation of factory resets, including how to perform one.
-- [Ship Troubleshooting](/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.
+- [Ship Troubleshooting](https://urbit.org/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.

--- a/content/reference/glossary/rollups.md
+++ b/content/reference/glossary/rollups.md
@@ -24,7 +24,7 @@ blockchains.
 
 - [Layer 2 for planets](/getting-started/layer-2-for-planets): Essential
   information for planet owners on layer 2 or considering a move to layer 2
-- [The Gang Solves the Gas Crisis](/blog/rollups): A casual overview of how
+- [The Gang Solves the Gas Crisis](https://urbit.org/blog/rollups): A casual overview of how
 naive rollups works.
 - [Layer 2 Overview](/reference/azimuth/l2/layer2): where developers should go to learn
 about the technical details of naive rollups.

--- a/content/reference/glossary/ship.md
+++ b/content/reference/glossary/ship.md
@@ -20,6 +20,6 @@ To be able to use the Arvo network, planets, stars, and galaxies must be combine
 ### Further Reading
 
 - [Using Bridge](/getting-started/): A guide to installing Urbit and booting a ship.
-- [Ship Troubleshooting](/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.
+- [Ship Troubleshooting](https://urbit.org/using/os/ship-troubleshooting): General instructions on getting your ship to work, which includes network connectivity issues.
 - [Understanding Urbit ID](/understanding-urbit/urbit-id)
 - [Pier](/reference/glossary/pier): The directory containing a ship's state.

--- a/content/reference/glossary/sync.md
+++ b/content/reference/glossary/sync.md
@@ -12,4 +12,4 @@ By default, in the [galaxy](/reference/glossary/galaxy)/[star](/reference/glossa
 
 ### Further Reading
 
-- [Using Your Ship](/using/os/filesystem): A user guide that includes instructions on using Clay commands, including `|sync`.
+- [Using Your Ship](https://urbit.org/using/os/filesystem): A user guide that includes instructions on using Clay commands, including `|sync`.

--- a/pages/guides/[[...slug]].js
+++ b/pages/guides/[[...slug]].js
@@ -83,7 +83,7 @@ export default function GuidePage({
           <a
             className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
-            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/docs/${
+            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/guides/${
               params.slug?.join("/") || "_index"
             }.md`}
           >

--- a/pages/reference/[[...slug]].js
+++ b/pages/reference/[[...slug]].js
@@ -79,7 +79,7 @@ export default function GuidePage({
           <a
             className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
-            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/docs/${
+            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/reference/${
               params.slug?.join("/") || "_index"
             }.md`}
           >


### PR DESCRIPTION
Correct backlinks to urbit.org.

(actually throughout, not just glossary)