### PR TITLE
events: support multi-day events as happening now

### DIFF
--- a/pages/community/events/index.js
+++ b/pages/community/events/index.js
@@ -40,10 +40,7 @@ export default function Events({ events, search }) {
   const happeningNow = events.filter((event) => {
     const starts = generateRealtimeDate(event.starts);
     const ends = generateRealtimeDate(event.ends);
-    return (
-      (starts > DateTime.now() && ends < now) ||
-      (starts < DateTime.now() && ends > now)
-    );
+    return starts < DateTime.now() && ends > now;
   });
 
   return (

--- a/pages/community/events/index.js
+++ b/pages/community/events/index.js
@@ -40,7 +40,10 @@ export default function Events({ events, search }) {
   const happeningNow = events.filter((event) => {
     const starts = generateRealtimeDate(event.starts);
     const ends = generateRealtimeDate(event.ends);
-    return starts > DateTime.now() && ends < now;
+    return (
+      (starts > DateTime.now() && ends < now) ||
+      (starts < DateTime.now() && ends > now)
+    );
   });
 
   return (


### PR DESCRIPTION
Currently an edge case on urbit.org + dev.urbit.org is that multi-day events we're in the middle of don't get shown on the events page at all. Why? Because we do some date math to sort events into buckets, and multi-day events aren't in the future nor are they in the past. But looking at our current logic befuddles me:

```js
starts > DateTime.now() && ends < now
```

Does this even work? If it starts *after* now and ends *before* now, it's "now"?

Reversing this is more intuitive and displays our current event on this site:

```js
starts < DateTime.now() && ends > now
```

If it starts before now and ends after now, it's now.