### PR TITLE
j-stdlib-text: fix split string example

### DIFF
--- a/content/guides/core/hoon-school/J-stdlib-text.md
+++ b/content/guides/core/hoon-school/J-stdlib-text.md
@@ -346,7 +346,7 @@ Hoon has a very powerful text parsing engine, built to compile Hoon itself.  How
     =/  result  *(list tape)  
     |-  ^-  (list tape)  
     ?:  =(index (lent ex))  
-      result  
+      (weld result ~[`tape`(scag index ex)])
     ?:  =((snag index ex) ' ')  
       $(index 0, ex `tape`(slag +(index) ex), result (weld result ~[`tape`(scag index ex)]))    
     $(index +(index))


### PR DESCRIPTION
Previously the example code for string splitting was "off by one" (e.g., when splitting "this is a test", it would return ["this" "is" "a"]. This change welds the result list with the final word from the input tape in the recursive base case.

Before:
```
> +tapesplit `tape`"this is a test"
<<"this" "is" "a">>
```

After:
```
> +tapesplit `tape`"this is a test"
<<"this" "is" "a" "test">>
```

I think there's a more elegant base case (without the use of `weld`), but alas I am a novice hooner. Perhaps you have an idea on how to simplify it,  @sigilante.