### PR TITLE
j-stdlib: update generator name to match instructions

### DIFF
--- a/content/guides/core/hoon-school/J-stdlib-text.md
+++ b/content/guides/core/hoon-school/J-stdlib-text.md
@@ -479,7 +479,7 @@ Run it with:
 ```hoon
 > |commit %base
 
-> +say
+> +add
 42
 ```
 


### PR DESCRIPTION
In the previous paragraph, the reader is instructed to save a generator as `add.hoon`. This updates the example to use `+add` to call it.