### PR TITLE
remove typo in both 8 ball say generators

### DIFF
--- a/content/guides/core/hoon-school/J-stdlib-text.md
+++ b/content/guides/core/hoon-school/J-stdlib-text.md
@@ -532,7 +532,7 @@ This Magic 8-Ball generator returns one of a variety of answers in response to a
 ^-  tape
 =/  answers=(list tape)
   :~  "It is certain."
-      "It is decidedly so."****
+      "It is decidedly so."
       "Without a doubt."
       "Yes - definitely."
       "You may rely on it."

--- a/content/guides/core/hoon-school/O-subject.md
+++ b/content/guides/core/hoon-school/O-subject.md
@@ -397,7 +397,7 @@ The Magic 8-Ball returns one of a variety of answers in response to a call.  In 
 ^-  tape
 =/  answers=(list tape)
   :~  "It is certain."
-      "It is decidedly so."****
+      "It is decidedly so."
       "Without a doubt."
       "Yes - definitely."
       "You may rely on it."


### PR DESCRIPTION
This PR  removes extraneous `****` in both copies of the magic 8 ball %say generator examples