### PR TITLE
k-doors: remove extraneous `playing-cards` ref

### DIFF
--- a/content/guides/core/hoon-school/K-doors.md
+++ b/content/guides/core/hoon-school/K-doors.md
@@ -509,7 +509,7 @@ You can apply a gate to each value, rather like `++turn` in Lesson 4, using `++r
       (~(got by card-table) c)
     ++  card-table
       %-  malt
-      ^-  (list [darc:playing-cards @t])
+      ^-  (list [darc @t])
       :~  :-  [sut=%clubs val=1]  '🃑'
           :-  [sut=%clubs val=2]  '🃒'
           :-  [sut=%clubs val=3]  '🃓'


### PR DESCRIPTION
Adding the additional gates as described [in this exercise](https://developers.urbit.org/guides/core/hoon-school/K-doors#exercise-display-cards=) was causing compilations of `playing-cards.hoon` to fail. Turns out that `:playing-cards` the reference is not necessary when it's an arm within the parent core.

*Before*
```
kiln: commit detected at %base (local)
: /~dev/base/133/lib/playing-cards/hoon
clay: read-at-aeon fail [desk=%base care=%a case=[%da p=~2022.7.17..06.29.42..01ad] path=/lib/playing-cards/hoon]
/sys/vane/clay/hoon:<[911 30].[911 50]>
/lib/playing-cards/hoon::[1 1].[109 3]>
/lib/playing-cards/hoon::[51 3].[52 27]>
/lib/playing-cards/hoon::[52 3].[52 27]>
/lib/playing-cards/hoon::[52 4].[52 24]>
%redo-match
/lib/playing-cards/hoon::[54 3].[108 5]>
%redo-match
/lib/playing-cards/hoon::[55 13].[55 36]>
/lib/playing-cards/hoon::[55 14].[55 32]>
-find.playing-cards
> =playing-cards -build-file /===/lib/playing-cards/hoon
thread failed: %build-file
```

*After*
```
> =playing-cards -build-file /===/lib/playing-cards/hoon
~dev:dojo>
```