### PR TITLE
changed shell to dojo and re-ordered overview sections

### DIFF
--- a/components/icons/dojo.js
+++ b/components/icons/dojo.js
@@ -1,0 +1,16 @@
+export default function Dojo() {
+  return (
+    <svg
+      width="80"
+      height="80"
+      viewBox="0 0 80 80"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+<path d="M61 32H34V20H61V32ZM46 47H34V35H46V47ZM19 20H31V47H19V20ZM19 50H46V62H19V50ZM61 62H49V35H61V62Z" stroke="black"/>
+
+    </svg>
+  );
+}
+
+

--- a/components/icons/index.js
+++ b/components/icons/index.js
@@ -13,3 +13,4 @@ export { default as Nock } from "./nock";
 export { default as Peer } from "./peer";
 export { default as Ringsig } from "./ringsig";
 export { default as Vere } from "./vere";
+export { default as Dojo } from "./dojo";

--- a/content/overview/_index.md
+++ b/content/overview/_index.md
@@ -21,7 +21,7 @@ The Urbit stack primarily comprises:
   virtual machine that mediates between each urbit and the Unix software layer.
 - [Azimuth](/overview/azimuth): the Urbit identity layer, built
   on the Ethereum blockchain as a public-key infrastructure.
-- [Dojo](/overview/shell): the
+- [Dojo](/overview/dojo): the
   [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
   command-line interface to your Urbit instance.
 

--- a/content/overview/azimuth.md
+++ b/content/overview/azimuth.md
@@ -1,6 +1,6 @@
 +++
 title = "Azimuth"
-weight = 50
+weight = 20
 +++
 
 

--- a/content/overview/dojo.md
+++ b/content/overview/dojo.md
@@ -1,6 +1,6 @@
 +++
-title = "Shell"
-weight = 2
+title = "Dojo"
+weight = 50
 +++
 
 The Dojo is our shell; it processes system commands and returns output. It's a

--- a/content/overview/hoon.md
+++ b/content/overview/hoon.md
@@ -1,6 +1,6 @@
 +++
 title = "Hoon"
-weight = 20
+weight = 30
 +++
 
 Hoon is a strictly typed functional programming language that compiles itself

--- a/content/overview/nock.md
+++ b/content/overview/nock.md
@@ -1,6 +1,6 @@
 +++
 title = "Nock"
-weight = 30
+weight = 40
 +++
 
 

--- a/content/overview/vere.md
+++ b/content/overview/vere.md
@@ -1,6 +1,6 @@
 +++
 title = "Vere"
-weight = 40
+weight = 60
 +++
 
 

--- a/pages/overview/[[...slug]].js
+++ b/pages/overview/[[...slug]].js
@@ -22,6 +22,7 @@ import {
   Vere,
   Azimuth,
   Cryptography,
+  Dojo,
 } from "../../components/icons";
 import Footer from "../../components/Footer";
 import overviewTree from "../../cache/overview.json";
@@ -300,20 +301,36 @@ function Landing({ search }) {
               href="/overview/arvo"
             />
             <Card
+              icon={<Azimuth />}
+              title="Azimuth"
+              text="A general-purpose public-key infrastructure (PKI) on the Ethereum blockchain"
+              className="h-full"
+              href="/overview/azimuth"
+            />
+          </TwoUp>
+          <TwoUp>
+            <Card
               icon={<Hoon />}
               title="Hoon"
               text="A strictly typed functional programming language that compiles itself to Nock"
               className="h-full"
               href="/overview/hoon"
             />
-          </TwoUp>
-          <TwoUp>
             <Card
               icon={<Nock />}
               title="Nock"
               text="A low-level homoiconic combinator language"
               className="h-full"
               href="/overview/nock"
+            />
+          </TwoUp>
+          <TwoUp>
+            <Card
+              icon={<Dojo />}
+              title="Dojo"
+              text="Dojo is a system for operating on and transforming data in Urbit"
+              className="h-full"
+              href="/overview/dojo"
             />
             <Card
               icon={<Vere />}
@@ -322,16 +339,6 @@ function Landing({ search }) {
               className="h-full"
               href="/overview/vere"
             />
-          </TwoUp>
-          <TwoUp>
-            <Card
-              icon={<Azimuth />}
-              title="Azimuth"
-              text="A general-purpose public-key infrastructure (PKI) on the Ethereum blockchain"
-              className="h-full"
-              href="/overview/azimuth"
-            />
-            <div />
           </TwoUp>
         </Section>
       </SingleColumn>


### PR DESCRIPTION
changed shell to dojo for consistency in using urbit nomenclature as titles, and added icon.

this ordering seemed to make more sense, lmk if you think otherwise.
