### PR TITLE
Escape backticks properly

### DIFF
--- a/content/guides/core/hoon-school/F-cores.md
+++ b/content/guides/core/hoon-school/F-cores.md
@@ -244,7 +244,7 @@ For example, given the `tape` `"hello"`, the generator should return the list `~
 Two tools that may help:
 
 - You can retrieve the _n_-th element in a `tape` using the [`++snag`](/reference/hoon/stdlib/2b#snag) gate, e.g. `(snag 3 `(list @ud)`~[1 2 3 4 5])` yields `4` (so `++snag` is zero-indexed; it counts from zero).
-- You can join an element to a list using the [`++snoc`](/reference/hoon/stdlib/2b#snoc) gate, e.g. `(snoc `(list @ud)`~[1 2 3] 4)` yields `~[1 2 3 4]`.
+- You can join an element to a list using the [`++snoc`](/reference/hoon/stdlib/2b#snoc) gate, e.g. ``(snoc `(list @ud)`~[1 2 3] 4)`` yields `~[1 2 3 4]`.
 
 ```hoon
 |=  [input=tape]


### PR DESCRIPTION
The backticks of an aura were closing a markdown code block. (`(snoc `(list @ud)`~[1 2 3] 4)`). I changed them to double backticks so now they appear as they are supposed to (``(snoc `(list @ud)`~[1 2 3] 4)``).