### PR TITLE
reference: tree nav ignores subanchors

### DIFF
--- a/pages/reference/[[...slug]].js
+++ b/pages/reference/[[...slug]].js
@@ -117,14 +117,17 @@ const SidebarContent = ({ root, posts }) => {
   );
 
   const pageTree = (thisLink, tree, level = 0) => {
-    const firstCrumb = "/" + router.asPath.split("/").slice(1).join("/");
+    const firstCrumb =
+      "/" + router.asPath.split("/").slice(1).join("/").split("#")[0];
     const includesThisPage = firstCrumb.includes(thisLink);
     const isThisPage = router.asPath === thisLink;
     const [isOpen, toggleTree] = useState(includesThisPage);
     useEffect(() => {
       const handleRouteChange = () => {
-        const firstCrumb = "/" + router.asPath.split("/").slice(1).join("/");
+        const firstCrumb =
+          "/" + router.asPath.split("/").slice(1).join("/").split("#")[0];
         const includesThisPage = firstCrumb.includes(thisLink);
+        console.log(firstCrumb);
         toggleTree(includesThisPage);
       };
 


### PR DESCRIPTION
Searching for something that was a subheading on a page (like `jest`) would skip the tree navigation flow in the reference view because it was too specific for comparison. We remove all params / subanchors / ids / whatever you call `#this` when doing the comparison now.