### PR TITLE
app-school: remove Ford reference

### DIFF
--- a/content/guides/core/app-school/3-imports-and-aliases.md
+++ b/content/guides/core/app-school/3-imports-and-aliases.md
@@ -184,9 +184,7 @@ the concepts discussed here:
 
 The first line uses the faslus (`/+`) Ford rune to import
 `/lib/default-agent.hoon` and `/lib/dbug.hoon`, building them and loading them
-into the subject of our agent so they're available for use. You can read more
-about Ford runes in the [Ford section of the vane
-documenation](/reference/arvo/ford/ford#ford-runes).
+into the subject of our agent so they're available for use.
 
 Next, we've added an extra core. Notice how it's not explicitly composed, since
 the build system will do that for us. In this case we've just added a single

--- a/content/guides/core/app-school/3-imports-and-aliases.md
+++ b/content/guides/core/app-school/3-imports-and-aliases.md
@@ -186,7 +186,7 @@ The first line uses the faslus (`/+`) Ford rune to import
 `/lib/default-agent.hoon` and `/lib/dbug.hoon`, building them and loading them
 into the subject of our agent so they're available for use. You can read more
 about Ford runes in the [Ford section of the vane
-documenation](/reference/hoon/rune/fas).
+documentation](/reference/hoon/rune/fas).
 
 Next, we've added an extra core. Notice how it's not explicitly composed, since
 the build system will do that for us. In this case we've just added a single

--- a/content/guides/core/app-school/3-imports-and-aliases.md
+++ b/content/guides/core/app-school/3-imports-and-aliases.md
@@ -184,7 +184,9 @@ the concepts discussed here:
 
 The first line uses the faslus (`/+`) Ford rune to import
 `/lib/default-agent.hoon` and `/lib/dbug.hoon`, building them and loading them
-into the subject of our agent so they're available for use.
+into the subject of our agent so they're available for use. You can read more
+about Ford runes in the [Ford section of the vane
+documenation](/reference/hoon/rune/fas).
 
 Next, we've added an extra core. Notice how it's not explicitly composed, since
 the build system will do that for us. In this case we've just added a single


### PR DESCRIPTION
Remove reference to `ford` being its own vane, since it's now part of `clay`.