### PR TITLE
Fix summary of ++skim

### DIFF
--- a/content/reference/hoon/stdlib/2b.md
+++ b/content/reference/hoon/stdlib/2b.md
@@ -992,7 +992,7 @@ A cell of two lists.
 
 ## `++skim`
 
-Suffix
+Filter
 
 Cycles through the members of a list `a`, passing them to a gate `b` and
 producing a list of all of the members that produce `%.y`. Inverse of


### PR DESCRIPTION
Currently, ++skim is summarized as "Suffix". I change this to "Filter" which should be familiar to any functional programming language enthusiasts