### PR TITLE
Clarify: behn takes %rest and  %wait on same wire

### DIFF
--- a/content/reference/arvo/behn/tasks.md
+++ b/content/reference/arvo/behn/tasks.md
@@ -29,7 +29,7 @@ Behn does not return any `gift` in response to a `%born` `task`.
 
 Cancel a timer.
 
-Behn takes in a `@da` and cancels the timer at that time if it exists, then adjusts the next wakeup call from Unix if necessary.
+Behn takes in a `@da` and cancels the timer at that time if one had been set through that `wire`, then adjusts the next wakeup call from Unix if necessary.
 
 #### Returns
 


### PR DESCRIPTION
This tripped me up, as I thought the wires were strictly for my internal bookkeeping and not something others cared about (as opposed to paths).

Not sure how to phrase it in the best way (and I also don't know if this applies to other parts of the system than agents), but here's a suggestion.