### PR TITLE
fix rune subheading links, replace `{% customFence %}` with code block, and remove redundant heading id

### DIFF
--- a/content/guides/additional/strings.md
+++ b/content/guides/additional/strings.md
@@ -174,11 +174,11 @@ This is something to be wary of. For example, if you wanted to form a `(set @tas
 However, this will actually form a set of the union `?(%foo %bar %baz)` due to
 the specificity of type inference:
 
-{% customFence %}
-\> ? (silt (limo ~[%foo %bar %baz]))
+```
+> ? (silt (limo ~[%foo %bar %baz]))
 ?(%~ [?(n=%bar n=%baz n=%foo) l=nlr(?(%bar %baz %foo)) r=nlr(?(%bar %baz %foo))])
-[n=%baz l&#x7B;&#x25;bar} r=&#x7B;&#x25;foo}]
-{% /customFence %}
+[n=%baz l={%bar} r={%foo}]
+```
 
 One further note about the type-as-itself form: Ocassionally you may wish to
 form a union of strings which contain characters disallowed in `term`s. To get

--- a/content/guides/core/app-school/4-lifecycle.md
+++ b/content/guides/core/app-school/4-lifecycle.md
@@ -90,7 +90,7 @@ In addition to each of those individual state versions, you'd also define a
 structure called `versioned-state`, which just contains a union of all the
 possible states. This way, the vase `on-load` receives can be unpacked to a
 `versioned-state` type, and then a
-[wuthep](/reference/hoon/rune/wut#-wuthep) (`?-`) expression can switch on
+[wuthep](/reference/hoon/rune/wut#--wuthep) (`?-`) expression can switch on
 the head (`%0`, `%1`, `%2`, etc) and process each one appropriately.
 
 For example, your state definition core might initially look like:
@@ -197,7 +197,7 @@ from an old version to the new version if necessary, and load it into the
 
 The vase would be unpacked with a
 [zapgal](/reference/hoon/rune/zap#-zapgal) (`!<`) rune, and then typically
-you'd test its version with a [wuthep](/reference/hoon/rune/wut#-wuthep)
+you'd test its version with a [wuthep](/reference/hoon/rune/wut#--wuthep)
 (`?-`) expression.
 
 ## Example

--- a/content/guides/core/hoon-school/B-syntax.md
+++ b/content/guides/core/hoon-school/B-syntax.md
@@ -91,7 +91,7 @@ Hearkening back to our discussion of interchangeable representations in Lesson -
 
 There's a special value that recurs in many contexts in Hoon:  `~` sig is the null or zero value.
 
-The [`^-` kethep](/reference/hoon/rune/ket#-kethep) rune is useful for ensuring that everything in the second child matches the type (aura) of the first, e.g.
+The [`^-` kethep](/reference/hoon/rune/ket#--kethep) rune is useful for ensuring that everything in the second child matches the type (aura) of the first, e.g.
 
 ```
 ^-  @ux  0x1ab4
@@ -119,7 +119,7 @@ A cell is a pair of nouns.  Cells are traditionally written using square bracket
 [[1 2] [3 4]]
 ```
 
-This is actually a shorthand for a rune as well, [`:-` colhep](/reference/hoon/rune/col#-colhep):
+This is actually a shorthand for a rune as well, [`:-` colhep](/reference/hoon/rune/col#--colhep):
 
 ```
 :-  1  2
@@ -231,7 +231,7 @@ Here is a snippet of Hoon code:
  
 Without looking it up first, what does the [`==` tistis](/reference/hoon/rune/terminators#-tistis) do for the [`:~` colsig](/reference/hoon/rune/col#-colsig) rune?  Hint:  some runes can take any number of arguments.
 
-> Most runes are used at the beginning of a complex expression, but there are exceptions. For example, the runes [`--` hephep](/reference/hoon/rune/terminators#-hephep) and [`==` tistis](/reference/hoon/rune/terminators#-tistis) are used at the end of certain expressions.
+> Most runes are used at the beginning of a complex expression, but there are exceptions. For example, the runes [`--` hephep](/reference/hoon/rune/terminators#---hephep) and [`==` tistis](/reference/hoon/rune/terminators#-tistis) are used at the end of certain expressions.
 
 #### Aside:  Writing Incorrect Code
 

--- a/content/guides/core/hoon-school/D-gates.md
+++ b/content/guides/core/hoon-school/D-gates.md
@@ -11,7 +11,7 @@ _This module will teach you how to produce deferred computations for later use, 
 
 Until this point in Hoon School, we have rigorously adhered to the regular syntax of runes so that you could get used to using them.  In fact, the only two irregular forms we used were these:
 
-- Cell definition `[a b]` which represents the [`:-` colhep](/reference/hoon/rune/col#-colhep) rune, `:-  a  b`.
+- Cell definition `[a b]` which represents the [`:-` colhep](/reference/hoon/rune/col#--colhep) rune, `:-  a  b`.
 
     That is, these expressions are all the same for Hoon:
 
@@ -28,7 +28,7 @@ Until this point in Hoon School, we have rigorously adhered to the regular synta
     [1 2]
     ```
 
-- Aura application `` `@ux`500 `` which represents a double [`^-` kethep](/reference/hoon/rune/ket#-kethep), `^-  @ux  ^-  @  500`.
+- Aura application `` `@ux`500 `` which represents a double [`^-` kethep](/reference/hoon/rune/ket#--kethep), `^-  @ux  ^-  @  500`.
 
     These are equivalent in Hoon:
 
@@ -114,7 +114,7 @@ Beyond those, what is the purpose of each line?
 
 The [`spec`](/reference/hoon/stdlib/4o#spec) gives the type as a mold and attaches a face to it for use in the gate.
 
-The [`hoon`](/reference/hoon/stdlib/4o#hoon) body expression evaluates and yields a result, ultimately sent back to the call site.  Frequently it is wise to explicitly require a particular type for the return value using the [`^-` kethep](/reference/hoon/rune/ket#-kethep) rune:
+The [`hoon`](/reference/hoon/stdlib/4o#hoon) body expression evaluates and yields a result, ultimately sent back to the call site.  Frequently it is wise to explicitly require a particular type for the return value using the [`^-` kethep](/reference/hoon/rune/ket#--kethep) rune:
 
 ```hoon {% copy=true %}
 ::  Confirm whether a value is greater than one.

--- a/content/guides/core/hoon-school/F-cores.md
+++ b/content/guides/core/hoon-school/F-cores.md
@@ -20,7 +20,7 @@ Computers were built and designed to carry out tasks which were too dainty and t
 
 In programming, we call this behavior a “loop”.  A loop describes the situation in which we set up some condition, and repeat a process over and over until something we do meets that condition.  _Most_ of the time, this means counting once for each item in a collection, like a list.
 
-Hoon effects the concept of a loop using recursion, return to a particular point in an expression (presumably with some different values).  One way to do this is using the [`|-` barhep](/reference/hoon/rune/bar#-barhep) rune, which creates a structure called a _trap_.  (Think of the “trap” in the bottom of your sink.)  It means a point to which you can return again, perhaps with some key values (like a counter) changed.  Then you can repeat the calculation inside the trap again.  This continues until some single value, some noun, results, thereby handing a value back out of the expression.  (Remember that every Hoon expression results in a value.)
+Hoon effects the concept of a loop using recursion, return to a particular point in an expression (presumably with some different values).  One way to do this is using the [`|-` barhep](/reference/hoon/rune/bar#--barhep) rune, which creates a structure called a _trap_.  (Think of the “trap” in the bottom of your sink.)  It means a point to which you can return again, perhaps with some key values (like a counter) changed.  Then you can repeat the calculation inside the trap again.  This continues until some single value, some noun, results, thereby handing a value back out of the expression.  (Remember that every Hoon expression results in a value.)
 
 This program adds 1+2+3+4+5 and returns the sum:
 

--- a/content/guides/core/hoon-school/H-libraries.md
+++ b/content/guides/core/hoon-school/H-libraries.md
@@ -208,7 +208,7 @@ We add a bunted `deck`, then encounter a very interesting statement that you hav
 
 With `=/  remaining  (lent unshuffled)`, we get the length of the unshuffled deck with [`++lent`](/reference/hoon/stdlib/2b#lent).
 
-`?:  =(remaining 1)` checks if we have only one card remaining. If that's true, we produce a cell of `shuffled` and the one card left in `unshuffled`. We use the [`:_` colcab](/reference/hoon/rune/col#-colcab) rune here, so that the “heavier” expression is at the bottom.
+`?:  =(remaining 1)` checks if we have only one card remaining. If that's true, we produce a cell of `shuffled` and the one card left in `unshuffled`. We use the [`:_` colcab](/reference/hoon/rune/col#_-colcab) rune here, so that the “heavier” expression is at the bottom.
 
 If the above conditional evaluates to `%.n` false, we need to do a little work. [`=^` tisket](/reference/hoon/rune/tis#-tisket) is a rune that pins the head of a pair and changes a leg in the subject with the tail.  It's useful for interacting with the `og` core arms, as many of them produce a pair of a random numbers and the next state of the core.  We're going to put the random number in the subject with the face `index` and change `random` to be the next core.
 

--- a/content/guides/core/hoon-school/I-testing.md
+++ b/content/guides/core/hoon-school/I-testing.md
@@ -172,7 +172,7 @@ Formal error messages in Urbit are built of tanks.
 
 As your code evaluates, the Arvo runtime maintains a _stack trace_, or list of the evaluations and expressions that got the program to its notional point of computation.  When the code fails, any error hints currently on the stack are dumped to the terminal for you to see what has gone wrong.
 
-- The [`~_` sigcab](/reference/hoon/rune/sig/#-sigcab) rune, described as a “user-formatted tracing printf”, can include an error message for you, requiring you to explicitly build the `tank`.  (`printf` is a reference to [C's I/O library](https://en.wikipedia.org/wiki/Printf_format_string).)
+- The [`~_` sigcab](/reference/hoon/rune/sig/#_-sigcab) rune, described as a “user-formatted tracing printf”, can include an error message for you, requiring you to explicitly build the `tank`.  (`printf` is a reference to [C's I/O library](https://en.wikipedia.org/wiki/Printf_format_string).)
 - The [`~|` sigbar](/reference/hoon/rune/sig/#-sigbar) rune, a “tracing printf”, can include an error message from a simple `@t` cord.
 
     What this means is that these print to the stack trace if something fails, so you can use either rune to contribute to the error description:

--- a/content/guides/core/hoon-school/K-doors.md
+++ b/content/guides/core/hoon-school/K-doors.md
@@ -923,7 +923,7 @@ This code calculates the volume of a cylinder, _A=πr²h_.
 
 Since all of the values either have to be pinned ahead of time or made available as arms, a `|^` barket would probably be used inside of a gate.  Of course, since it is a core with a `$` buc arm, one could also use it recursively to calculate values like the factorial.
 
-If you read the docs, you'll find that a [`|-` barhep](/reference/hoon/rune/bar#-barhep) rune “produces a trap (a core with one arm `$`) and evaluates it.”  So a trap actually evaluates to a `|%` barcen core with an arm `$`:
+If you read the docs, you'll find that a [`|-` barhep](/reference/hoon/rune/bar#--barhep) rune “produces a trap (a core with one arm `$`) and evaluates it.”  So a trap actually evaluates to a `|%` barcen core with an arm `$`:
 
 ```hoon {% copy=true %}
 :: count to five

--- a/content/guides/core/hoon-school/M-typecheck.md
+++ b/content/guides/core/hoon-school/M-typecheck.md
@@ -92,7 +92,7 @@ The most obvious case is when there is a casting `^` ket rune in your code.  The
 
 #### `^-` kethep Cast with a Type
 
-You've already seen one rune that calls for a type check:  [`^-` kethep](/reference/hoon/rune/ket#-kethep):
+You've already seen one rune that calls for a type check:  [`^-` kethep](/reference/hoon/rune/ket#--kethep):
 
 ```hoon
 > ^-(@ 12)
@@ -688,7 +688,7 @@ So far you've learned about four kinds of type inference:
 3.  gate sample definitions
 4.  branch specialization using runes in the `?` family
 
-There are several other ways that Hoon infers type.  Any rune expression that evaluates to a `?` flag, e.g., `.=` dottis, will be inferred from accordingly.  The `.+` dotlus rune always evaluates to an `@`, and Hoon knows that too.  The cell constructor runes, [`:-` colhep](/reference/hoon/rune/col#-colhep), [`:+` collus](/reference/hoon/rune/col#-collus), [`:^` colket](/reference/hoon/rune/col#-colket), and [`:*` coltar](/reference/hoon/rune/col#-coltar) are all known to produce cells.
+There are several other ways that Hoon infers type.  Any rune expression that evaluates to a `?` flag, e.g., `.=` dottis, will be inferred from accordingly.  The `.+` dotlus rune always evaluates to an `@`, and Hoon knows that too.  The cell constructor runes, [`:-` colhep](/reference/hoon/rune/col#--colhep), [`:+` collus](/reference/hoon/rune/col#-collus), [`:^` colket](/reference/hoon/rune/col#-colket), and [`:*` coltar](/reference/hoon/rune/col#-coltar) are all known to produce cells.
 
 More subtly, the [`=+` tislus](/reference/hoon/rune/tis#-tislus), [`=/` tisfas](/reference/hoon/rune/tis#-tisfas), and [`=|` tisbar](/reference/hoon/rune/tis#-tisbar) runes modify the subject by pinning values to the head.  Hoon infers from this that the subject has a new type:  a cell whose head is the type of the pinned value and whose tail is the type of the (old) subject.
 

--- a/content/guides/core/hoon-school/N-logic.md
+++ b/content/guides/core/hoon-school/N-logic.md
@@ -41,7 +41,7 @@ The key conditional decision-making rune is [`?:` wutcol](/reference/hoon/rune/w
 
 There are also two long-form decision-making runes, which we will call [_switch statements_](https://en.wikipedia.org/wiki/Switch_statement) by analogy with languages like C.
 
-- [`?-` wuthep](/reference/hoon/rune/wut#-wuthep) lets you choose between several possibilities, as with a type union.  Every case must be handled and no case can be unreachable.
+- [`?-` wuthep](/reference/hoon/rune/wut#--wuthep) lets you choose between several possibilities, as with a type union.  Every case must be handled and no case can be unreachable.
 
     Since `@tas` terms are constants first, and not `@tas` unless marked as such, `?-` wuthep switches over term unions can make it look like the expression is branching on the value.  It's actually branching on the _type_.  These are almost exclusively used with term type unions.
 

--- a/content/guides/core/hoon-school/P-stdlib-io.md
+++ b/content/guides/core/hoon-school/P-stdlib-io.md
@@ -209,24 +209,24 @@ For instance, how does `+cat` work?  Let's look at the structure of `/gen/cat/ho
   - `/?` faswut pins the expected Arvo kelvin version; right now it doesn't do anything.
   - [`.^` dotket](/reference/hoon/rune/dot#-dotket) loads a value from Arvo (called a “scry”).
   - [`++smyt`](/reference/hoon/stdlib/4m#smyt) pretty-prints a path.
-  - [`=-` tishep](/reference/hoon/rune/tis#-tishep) combines a faced noun with the subject, inverted relative to `=+` tislus/`=/` tisfas.
+  - [`=-` tishep](/reference/hoon/rune/tis#--tishep) combines a faced noun with the subject, inverted relative to `=+` tislus/`=/` tisfas.
 
 You can see how much of the generator is concerned with formatting the content of the file into a formatted text `tank` by prepending `%rose` tags and so forth.
 
 - Work line-by-line through the file and clarify parts that are muddy to you at first glance.
 
 ### Producing Error Messages
-                           
+
 Formal error messages in Urbit are built of tanks.  “A `tang` is a list of `tank`s, and a `tank` is a structure for printing data.  There are three types of `tank`: `leaf`, `palm`, and `rose`.  A `leaf` is for printing a single noun, a `rose` is for printing rows of data, and a `palm` is for printing backstep-indented lists.”
-          
-One way to include an error message in your code is the [`~_` sigcab](/reference/hoon/rune/sig/#-sigcab) rune, described as a “user-formatted tracing printf”, or the [`~|` sigbar](/reference/hoon/rune/sig/#-sigbar) rune, a “tracing printf”.  What this means is that these print to the stack trace if something fails, so you can use either rune to contribute to the error description:                                                         
+
+One way to include an error message in your code is the [`~_` sigcab](/reference/hoon/rune/sig#_-sigcab) rune, described as a “user-formatted tracing printf”, or the [`~|` sigbar](/reference/hoon/rune/sig#-sigbar) rune, a “tracing printf”.  What this means is that these print to the stack trace if something fails, so you can use either rune to contribute to the error description:
 
 ```hoon {% copy=true %}
 |=  [a=@ud]
   ~_  leaf+"This code failed"
   !!
-``` 
-      
+```
+
 When you compose your own library functions, consider including error messages for likely failure points.
 
 

--- a/content/guides/core/hoon-school/R-metals.md
+++ b/content/guides/core/hoon-school/R-metals.md
@@ -368,7 +368,7 @@ There's a simpler way to define an iron sample. Revise the first line of `/gen/g
 (add b 20)
 ```
 
-If you test it, you'll find that the generator behaves the same as it did before the edits.  The [`$-` buchep](/reference/hoon/rune/buc#-buchep) rune is used to create an `%iron` gate structure, i.e., an `%iron` gate type.  The first expression defines the desired sample type, and the second subexpression defines the gate's desired output type.
+If you test it, you'll find that the generator behaves the same as it did before the edits.  The [`$-` buchep](/reference/hoon/rune/buc#--buchep) rune is used to create an `%iron` gate structure, i.e., an `%iron` gate type.  The first expression defines the desired sample type, and the second subexpression defines the gate's desired output type.
 
 The sample type of an `%iron` gate is contravariant.  This means that, when doing a cast with some `%iron` gate, the desired gate must have either the same sample type or a superset.
 

--- a/content/reference/arvo/clay/scry.md
+++ b/content/reference/arvo/clay/scry.md
@@ -48,11 +48,10 @@ A scry with a `care` of `%d` will return a `(set desk)` of the `desk`s that exis
 
 Example:
 
-{% customFence %}
-
-\> .^((set desk) %cd %)  
-&#x7B;&#x25;bitcoin %base %landscape %webterm %garden}
-{% /customFence %}
+```
+> .^((set desk) %cd %)  
+{%bitcoin %base %landscape %webterm %garden %kids}
+```
 
 ## %e - Static mark core.
 

--- a/content/reference/hoon/hoon-errors.md
+++ b/content/reference/hoon/hoon-errors.md
@@ -134,7 +134,7 @@ function.
 ### `mint-vain` and `mint-lost`
 
 These are errors caused by type inference in pattern matching.
-`mint-vain` means this hoon is never executed. `mint-lost` means there's a case in a `?-` ([**wuthep**](/reference/hoon/rune/wut#-wuthep)) that isn't handled.
+`mint-vain` means this hoon is never executed. `mint-lost` means there's a case in a `?-` ([**wuthep**](/reference/hoon/rune/wut#--wuthep)) that isn't handled.
 
 ## Runtime crashes
 

--- a/content/reference/hoon/irregular.md
+++ b/content/reference/hoon/irregular.md
@@ -7,7 +7,7 @@ weight = 20
 
 | Form | Regular Form |
 | ---- | ------------ |
-| `_foo` | [`$_`](/reference/hoon/rune/buc#-buccab), normalizes to an example |
+| `_foo` | [`$_`](/reference/hoon/rune/buc#_-buccab), normalizes to an example |
 | `foo=bar` | [`$=`](/reference/hoon/rune/buc#-buctis), wraps a face around a value |
 | `?(%foo %bar %baz)` | [`$?`](/reference/hoon/rune/buc#-bucwut), forms a type union |
 | `(fun a b c)` | [`%:`](/reference/hoon/rune/cen#-cencol), calls a gate with n arguments |
@@ -17,7 +17,7 @@ weight = 20
 | `~[a b c]` | [`:~`](/reference/hoon/rune/col#-colsig), constructs null-terminated list |
 | `+(42)` | [`.+`](/reference/hoon/rune/dot#-dotlus), increments with Nock 4 |
 | `=(a b)` | [`.=`](/reference/hoon/rune/dot#-dottis), tests for equality wiht Nock 5 |
-| `` `foo` bar`` | [`^-`](/reference/hoon/rune/ket#-kethep), typecasts by explicit type label |
+| `` `foo` bar`` | [`^-`](/reference/hoon/rune/ket#--kethep), typecasts by explicit type label |
 | `foo=bar` | [`^=`](/reference/hoon/rune/ket#-kettis), binds name to value |
 | `*foo` | [`^*`](/reference/hoon/rune/ket#-kettar), bunts (produces default mold value) |
 | `,foo` | [`^:`](/reference/hoon/rune/ket#-ketcol), produces “factory” gate for type |
@@ -78,7 +78,7 @@ The cell runes.
 
 ### `:-` colhep
 
-[docs](/reference/hoon/rune/col#-colhep) \\[\\]\\^\\+\\\`\\~
+[docs](/reference/hoon/rune/col#--colhep) \\[\\]\\^\\/\\+\\\`\\~
 
 `[%clhp p=hoon q=hoon]`: construct a cell (2-tuple).
 
@@ -178,7 +178,7 @@ Irregular: `?(p)`
 
 ### `$_` buccab
 
-[docs](/reference/hoon/rune/buc#-buccab) \\\_
+[docs](/reference/hoon/rune/buc#_-buccab) \\\_
 
 `[%bccb p=value]`: mold which normalizes to an example.
 
@@ -236,7 +236,7 @@ Irregular: `,p`
 
 ### `^-` kethep
 
-[docs](/reference/hoon/rune/ket#-kethep) \\\`
+[docs](/reference/hoon/rune/ket#--kethep) \\\`
 
 `[%kthp p=model q=value]`: typecast by mold.
 

--- a/content/reference/hoon/rune/buc.md
+++ b/content/reference/hoon/rune/buc.md
@@ -573,7 +573,7 @@ Two arguments, fixed.
 
 #### Discussion
 
-Since a `$-` reduces to a [`$_`](#-buccab), it is not useful for normalizing, just for typechecking. In particular, the existence of `$-`s does **not** let us send gates or other cores over the network!
+Since a `$-` reduces to a [`$_`](#_-buccab), it is not useful for normalizing, just for typechecking. In particular, the existence of `$-`s does **not** let us send gates or other cores over the network!
 
 #### Examples
 

--- a/content/reference/hoon/rune/cen.md
+++ b/content/reference/hoon/rune/cen.md
@@ -318,7 +318,7 @@ value) for the gate.
 `%-` is used to call a function; `a` is the function
 ([`gate`](/reference/hoon/rune/bar#-bartis), `q` the argument. `%-` is a
 special case of [`%~` ("censig")](#-censig), and a gate is a special case of a
-[door](/reference/hoon/rune/bar#-barcab).
+[door](/reference/hoon/rune/bar#_-barcab).
 
 #### Examples
 
@@ -509,7 +509,7 @@ door itself. `c` is the sample of the door.
 
 `%~` is the general case of a function call, `%-`. In both, we replace the sample (`+6`) of a core. In `%-` the core is a gate and the `$` arm is evaluated. In `%~` the core is a door and any arm may be evaluated. You must identify the arm to be run: `%~(arm door arg)`.
 
-See also [`|_`](/reference/hoon/rune/bar#-barcab).
+See also [`|_`](/reference/hoon/rune/bar#_-barcab).
 
 #### Examples
 

--- a/content/reference/hoon/rune/dot.md
+++ b/content/reference/hoon/rune/dot.md
@@ -263,7 +263,7 @@ therefore possible to use Hoon as a typeless language.
 
 ---
 
-## `.=` "dottis" {% #-dottis %}
+## `.=` "dottis"
 
 Test for equality with Nock `5`.
 

--- a/content/reference/hoon/rune/ket.md
+++ b/content/reference/hoon/rune/ket.md
@@ -3,7 +3,7 @@ title = "Casts ^ ('ket')"
 weight = 11
 +++
 
-[`^-` ("kethep")](#-kethep), [`^+` ("ketlus")](#-ketlus), and [`^=`
+[`^-` ("kethep")](#--kethep), [`^+` ("ketlus")](#-ketlus), and [`^=`
 ("kettis")](#-kettis) let us adjust types without violating type constraints.
 
 The `nest` algorithm which tests subtyping is conservative; it never allows

--- a/content/reference/hoon/rune/tis.md
+++ b/content/reference/hoon/rune/tis.md
@@ -357,7 +357,7 @@ Three arguments, fixed.
 
 Technically the `=.` rune doesn't change the subject. It creates a new subject
 just like the old one except for a changed value at `p`. Note that the mutation
-uses [`%_` ("cencab")](/reference/hoon/rune/cen#-cencab), so the type at `p`
+uses [`%_` ("cencab")](/reference/hoon/rune/cen#_-cencab), so the type at `p`
 doesn't change. Trying to change the value type results in a `nest-fail`.
 
 #### Examples

--- a/content/reference/hoon/rune/wut.md
+++ b/content/reference/hoon/rune/wut.md
@@ -19,7 +19,7 @@ type for the branches of the `?:`. Branch inference also works
 for expressions which expand to `?:`.
 
 The test does not have to be a single `?=`; the compiler can
-analyze arbitrary boolean logic ([`?&` ("wutpam")](#wutpam),
+analyze arbitrary boolean logic ([`?&` ("wutpam")](#-wutpam),
 [`?|` ("wutbar")](#-wutbar), [`?!` ("wutzap")](#-wutzap)) with full
 short-circuiting. Equality tests ([`.=` ("dottis")](/reference/hoon/rune/dot#-dottis)) are **not**
 analyzed.

--- a/content/reference/hoon/stdlib/2i.md
+++ b/content/reference/hoon/stdlib/2i.md
@@ -824,13 +824,12 @@ A set.
 
 #### Examples
 
-{% customFence %}
+```
+> =a `(map @tas @)`(malt (limo ~[a+1 b+2 c+3 d+4]))
 
-\> =a `(map @tas @)`(malt (limo ~[a+1 b+2 c+3 d+4]))
-
-\> ~(key by a)
-{&#x7B;&#x25;b %d %a %c}
-{% /customFence %}
+> ~(key by a)
+{%b %d %a %c}
+```
 
 ---
 

--- a/content/reference/hoon/stdlib/4g.md
+++ b/content/reference/hoon/stdlib/4g.md
@@ -201,14 +201,14 @@ Either a `tape` or a crash.
 
 #### Source
 
-{% customFence %}
-++ scan |\* [los=tape sab=rule]
-=+ vex=((full sab) [[1 1] los])
-?~ q.vex
-~_ (show [%m '&#x7B;&#x25;d %d}'] p.p.vex q.p.vex ~)
-~_(leaf+"syntax error" !!)
-p.u.q.vex
-{% /customFence %}
+```hoon
+++  scan  |*  [los=tape sab=rule]
+          =+  vex=((full sab) [[1 1] los])
+          ?~  q.vex
+            ~_  (show [%m '{%d %d}'] p.p.vex q.p.vex ~)
+            ~_(leaf+"syntax error" !!)
+          p.u.q.vex
+```
 
 #### Examples
 

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -32,7 +32,7 @@ export const glossary = [
     name: "dottis",
     symbol: ".=",
     usage: "Nock",
-    slug: "https://developers.urbit.org/reference/hoon/rune/dot/#dottis",
+    slug: "https://developers.urbit.org/reference/hoon/rune/dot/#-dottis",
     desc: "<code>[%dtts p=hoon q=hoon]</code>: test for equality with Nock <code>5</code>.",
   },
   {
@@ -522,7 +522,7 @@ export const glossary = [
     name: "cenhep",
     symbol: "%-",
     usage: "Calls",
-    slug: "https://developers.urbit.org/reference/hoon/rune/cen/#cenhep",
+    slug: "https://developers.urbit.org/reference/hoon/rune/cen/#-cenhep",
     desc: "Call a gate (function).",
   },
   {


### PR DESCRIPTION
(dottis heading already has the id `-dottis`, so having `{% #-dottis %}` doesn't change it)