### PR TITLE
build: add math component

### DIFF
--- a/content/guides/core/hoon-school/B-syntax.md
+++ b/content/guides/core/hoon-school/B-syntax.md
@@ -510,7 +510,11 @@ Given a test expression like those above, we can use the `?:` wutcol rune to dec
 
 [Piecewise mathematical functions](https://en.wikipedia.org/wiki/Piecewise) require precisely this functionality.  For instance, the Heaviside function is a piecewise mathematical function which is equal to zero for inputs less than zero and one for inputs greater than or equal to zero.
 
-<img src="https://latex.codecogs.com/svg.image?\large&space;H(x)=\begin{cases}&space;1,&space;&&space;x&space;>&space;0&space;\\&space;0,&space;&&space;x&space;\le&space;0&space;\end{cases}" title="https://latex.codecogs.com/svg.image?\large H(x):=\begin{cases} 1, & x > 0 \\ 0, & x \le 0 \end{cases}" />
+{% math block=true %}
+H(x)
+=
+\begin{cases} 1, & x > 0 \\\ 0, & x \le 0 \end{cases}
+{% /math %}
 
 <!--$$
 H(x)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@iarna/toml": "^2.2.5",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tlon/sigil-js": "^1.4.5",
-        "@urbit/foundation-design-system": "^0.4.1",
+        "@urbit/foundation-design-system": "^0.5.0",
         "@urbit/markdoc": "^0.1.6",
         "axios": "^0.26.1",
         "buffer": "^6.0.3",
@@ -329,9 +329,9 @@
       "dev": true
     },
     "node_modules/@urbit/foundation-design-system": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@urbit/foundation-design-system/-/foundation-design-system-0.4.1.tgz",
-      "integrity": "sha512-EFGtqABqIlJYQhaCJ7p/GlS0Wq2MrtF1H0vXC5p1l+na+aV5CGT0oXIR5dDt4hUgCD1gh9rX0QI9qnu2YKpAeA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@urbit/foundation-design-system/-/foundation-design-system-0.5.0.tgz",
+      "integrity": "sha512-CbEsiJ6NpnF8aprnd4JnUn25iksTY5owVg8rQVBsXZdbCP7wfnyxGZd1Zg6kVxIFy32V8pXO5MZTaHxkIRWrNA==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "core-js": "^3.23.1",
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@urbit/foundation-design-system/node_modules/luxon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
-      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
       "engines": {
         "node": ">=12"
       }
@@ -742,9 +742,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
-      "integrity": "sha512-CVU1xvJEfJGhyCpBrzzzU1kjCfgsGUxhEvwUV2e/cOedYWHdmluamx+knDnmhqALddMG16fZvIqvs9aijsHHaA==",
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -2788,9 +2788,9 @@
       "dev": true
     },
     "@urbit/foundation-design-system": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@urbit/foundation-design-system/-/foundation-design-system-0.4.1.tgz",
-      "integrity": "sha512-EFGtqABqIlJYQhaCJ7p/GlS0Wq2MrtF1H0vXC5p1l+na+aV5CGT0oXIR5dDt4hUgCD1gh9rX0QI9qnu2YKpAeA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@urbit/foundation-design-system/-/foundation-design-system-0.5.0.tgz",
+      "integrity": "sha512-CbEsiJ6NpnF8aprnd4JnUn25iksTY5owVg8rQVBsXZdbCP7wfnyxGZd1Zg6kVxIFy32V8pXO5MZTaHxkIRWrNA==",
       "requires": {
         "@iarna/toml": "^2.2.5",
         "core-js": "^3.23.1",
@@ -2801,9 +2801,9 @@
       },
       "dependencies": {
         "luxon": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
-          "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+          "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw=="
         }
       }
     },
@@ -3054,9 +3054,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
-      "integrity": "sha512-CVU1xvJEfJGhyCpBrzzzU1kjCfgsGUxhEvwUV2e/cOedYWHdmluamx+knDnmhqALddMG16fZvIqvs9aijsHHaA=="
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@iarna/toml": "^2.2.5",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tlon/sigil-js": "^1.4.5",
-    "@urbit/foundation-design-system": "^0.4.1",
+    "@urbit/foundation-design-system": "^0.5.0",
     "@urbit/markdoc": "^0.1.6",
     "axios": "^0.26.1",
     "buffer": "^6.0.3",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,44 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+        <Script strategy="beforeInteractive" dangerouslySetInnerHTML={{
+          __html: `window.__MathJax_State__ = {
+          isReady: false,
+          promise: new Promise(resolve => {
+
+            window.MathJax = {
+              loader: {load: ['[tex]/autoload', '[tex]/ams']},
+              tex: {
+                packages: {'[+]': ['autoload', 'ams']},
+                processEscapes: true
+              },
+              jax: ["input/TeX","output/CommonHTML"],
+              options: {
+                renderActions: {
+                  addMenu: []
+                }
+              },
+              startup: {
+                typeset: false,
+                ready: () => {
+                  MathJax.startup.defaultReady();
+                  window.__MathJax_State__.isReady = true;
+                  resolve();
+                }
+              }
+            };
+          })
+        };`}}
+        />
+        <Script strategy="beforeInteractive" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" />
+      </body>
+    </Html>
+  )
+}

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -98,7 +98,8 @@ export async function getStaticProps({ params }) {
     "blog"
   );
 
-  const markdown = JSON.stringify(Markdown.parse({ post }));
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${post.content}` } }));
+
   return {
     props: { post, markdown, nextPost, previousPost },
   };

--- a/pages/community/opportunities.js
+++ b/pages/community/opportunities.js
@@ -25,7 +25,8 @@ export async function getStaticProps({ params }) {
   if (index === undefined) {
     index = null;
   }
-  const markdown = JSON.stringify(Markdown.parse({ post }));
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${post.content}` } }));
+
   return {
     props: { post, markdown, index },
   };

--- a/pages/community/support.js
+++ b/pages/community/support.js
@@ -25,7 +25,8 @@ export async function getStaticProps({ params }) {
   if (index === undefined) {
     index = null;
   }
-  const markdown = JSON.stringify(Markdown.parse({ post }));
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${post.content}` } }));
+
   return {
     props: { post, markdown, index },
   };

--- a/pages/guides/[[...slug]].js
+++ b/pages/guides/[[...slug]].js
@@ -83,9 +83,8 @@ export default function GuidePage({
           <a
             className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
-            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/guides/${
-              params.slug?.join("/") || "_index"
-            }.md`}
+            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/guides/${params.slug?.join("/") || "_index"
+              }.md`}
           >
             Edit this page on GitHub
           </a>
@@ -308,8 +307,7 @@ export async function getStaticProps({ params }) {
       "weight"
     ) || null;
 
-  const markdown = JSON.stringify(Markdown.parse({ post: { content } }));
-
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${content}` } }));
   return { props: { posts, data, markdown, params, previousPost, nextPost } };
 }
 

--- a/pages/overview/[[...slug]].js
+++ b/pages/overview/[[...slug]].js
@@ -82,9 +82,8 @@ export default function Overview({
           <a
             className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
-            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/overview/${
-              params.slug?.join("/") || "_index"
-            }.md`}
+            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/overview/${params.slug?.join("/") || "_index"
+              }.md`}
           >
             Edit this page on GitHub
           </a>
@@ -365,7 +364,7 @@ export async function getStaticProps({ params }) {
       "weight"
     ) || null;
 
-  const markdown = JSON.stringify(Markdown.parse({ post: { content } }));
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${content}` } }));
 
   return { props: { posts, data, markdown, params, previousPost, nextPost } };
 }

--- a/pages/reference/[[...slug]].js
+++ b/pages/reference/[[...slug]].js
@@ -81,9 +81,8 @@ export default function GuidePage({
           <a
             className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
-            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/reference/${
-              params.slug?.join("/") || "_index"
-            }.md`}
+            href={`https://github.com/urbit/developers.urbit.org/blob/master/content/reference/${params.slug?.join("/") || "_index"
+              }.md`}
           >
             Edit this page on GitHub
           </a>
@@ -130,7 +129,7 @@ export async function getStaticProps({ params }) {
       "weight"
     ) || null;
 
-  const markdown = JSON.stringify(Markdown.parse({ post: { content } }));
+  const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${content}` } }));
 
   return { props: { posts, data, markdown, params, previousPost, nextPost } };
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+const { Markdown } = require("@urbit/foundation-design-system");
 const markdoc = require("@urbit/markdoc");
 
 module.exports = {
@@ -11,9 +12,8 @@ module.exports = {
     ],
     transform: {
       md: (content) => {
-        const parsed = markdoc.parse(content);
-        const transform = markdoc.transform(parsed);
-        return markdoc.renderers.html(transform);
+        const parsed = Markdown.parse({ post: { content } });
+        return markdoc.renderers.html(parsed);
       },
     },
   },


### PR DESCRIPTION
Adds all appropriate scaffolding to support MathJax on developers.urbit.org and then adds the component to our Markdown renderer:

- Bumps foundation-design-system to 0.5.0
- Adds the MathJax import and sets its config in _document.js.

For an example, see the equation in "Making a decision" here:

https://developers-urbit-2z5afpdft-urbit.vercel.app/guides/core/hoon-school/B-syntax#making-a-decision

Due to the bump to 0.5.0, we also get deduplication of header IDs, which was an occasional bug when two of the same header were on a page, creating strange behaviour in the table of contents.

Feel free to try migrating equations in this PR and we can tweak it more, or merge at your leisure ...

Fixes #182 