### PR TITLE
Revise balanced leaves example

### DIFF
--- a/content/guides/core/hoon-school/G-trees.md
+++ b/content/guides/core/hoon-school/G-trees.md
@@ -46,7 +46,7 @@ Most of any possible tree will be unoccupied for any actual data structure.  For
 
     | Noun | Tree Diagram |
     | ---- | ------------ |
-    | `[[[1 2] 3] 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-1.png) | 
+    | `[[1 2] [3 4]]`<br><br>pretty printed:<br>`[[1 2] 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-1.png) | 
     | `[[1 2] 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-2.png) | 
     | `[1 2 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-3.png) | 
 

--- a/content/guides/core/hoon-school/G-trees.md
+++ b/content/guides/core/hoon-school/G-trees.md
@@ -42,13 +42,13 @@ Most of any possible tree will be unoccupied for any actual data structure.  For
 
 ##  Exercise:  Map Nouns to Tree Diagrams
 
-- Consider each of the following nouns.  Which tree diagram do they correspond to?
+- Consider each of the following nouns.  Which tree diagram do they correspond to?  (This is a matching exercise.)
 
     | Noun | Tree Diagram |
     | ---- | ------------ |
-    | `[[1 2] [3 4]]`<br><br>pretty printed:<br>`[[1 2] 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-1.png) | 
-    | `[[1 2] 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-2.png) | 
-    | `[1 2 3 4]` | ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-3.png) | 
+    | 1. `[[[1 2] 3] 4]` | A. ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-1.png) | 
+    | 2. `[[1 2] 3 4]` | B. ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-2.png) | 
+    | 3. `[1 2 3 4]` | C. ![](https://storage.googleapis.com/media.urbit.org/docs/userspace/hoon-school/binary-tree-exercise-3.png) | 
 
 ##  Exercise:  Produce a List of Numbers
 


### PR DESCRIPTION
When you pretty print the structure `[[1 2] [3 4]]` it displays as `[[1 2] 3 4]` in dojo,  
rather than `[[[1 2] 3] 4]` which may be closer akin to the structure beneath this one:
```
    [[[1 2] 3] 4]
     /           \
[[1 2] 3]         4
    /   \
[1 2]    3
 /   \
1     2
```