### PR TITLE
Syntax fix for core guide

### DIFF
--- a/content/guides/core/hoon-school/F-cores.md
+++ b/content/guides/core/hoon-school/F-cores.md
@@ -81,7 +81,7 @@ It is frequently helpful, when constructing these, to be able to output the valu
   sum
 %=  $
   counter  (add counter 1)
-  sum      (add sum counter))
+  sum      (add sum counter)
 ==
 ```
 
@@ -97,7 +97,7 @@ You can do even better using _interpolation_:
   sum
 %=  $
   counter  (add counter 1)
-  sum      (add sum counter))
+  sum      (add sum counter)
 ==
 ```
 


### PR DESCRIPTION
Noticed what I think is a syntax error on one of the first examples in the core guide.