### PR TITLE
Fix smol bugs in setup for chat-guide.md

### DIFF
--- a/content/guides/quickstart/chat-guide.md
+++ b/content/guides/quickstart/chat-guide.md
@@ -94,9 +94,9 @@ across that our app will depend on:
 
 ```shell {% copy=true %}
 mkdir -p hut/{app,sur,mar,lib}
-cp dev-comet/squad/mar/{bill*,hoon*,json*,kelvin*,mime*,noun*,ship*,txt*,docket-0*} hut/mar/
+cp -r dev-comet/squad/mar/{bill*,hoon*,json*,kelvin*,mime*,noun*,ship*,txt*,docket-0*} hut/mar/
 cp dev-comet/squad/lib/{agentio*,dbug*,default-agent*,skeleton*,docket*} hut/lib/
-cp dev-comet/squad/sur/{docket*, squad*} hut/sur/
+cp dev-comet/squad/sur/{docket*,squad*} hut/sur/
 cp dev-comet/garden/lib/mip.hoon hut/lib/
 ```
 


### PR DESCRIPTION
Just going through the doc and saw these super minor frictions, feel free to close if not necessary

First line, i got this when executing because of a `json` dir with `response.hoon` in it, so changed it to do `-r`
```
$ cp mycomet/squad/mar/{bill*,hoon*,json*,kelvin*,mime*,noun*,ship*,txt*,docket-0*} hut/mar/ 
cp: mycomet/squad/mar/json is a directory (not copied).
```

Second line:
```
$ cp -r mycomet/squad/sur/{docket*, squad*} hut/sur/
zsh: parse error near `}'
```