### PR TITLE
iris/iris.md: fix API Reference link

### DIFF
--- a/content/reference/arvo/iris/iris.md
+++ b/content/reference/arvo/iris/iris.md
@@ -11,6 +11,6 @@ Iris gets passed HTTP requests, makes the request to the specified URL, and retu
 
 [Data Types](/reference/arvo/iris/data-types) - Reference documentation of the data types used by Iris.
 
-[API Reference](/reference/arvo/eyre/tasks) - The `task`s Iris takes and the `gift`s it returns.
+[API Reference](/reference/arvo/iris/tasks) - The `task`s Iris takes and the `gift`s it returns.
 
 [Example](/reference/arvo/iris/example) - An example of using Iris to fetch a remote HTTP resource.


### PR DESCRIPTION
Link incorrectly pointed to eyre; this PR points it to iris.