### PR TITLE
fix typo, Sail -> Udon

### DIFF
--- a/content/reference/glossary/udon.md
+++ b/content/reference/glossary/udon.md
@@ -12,6 +12,6 @@ desc = "A domain specific language for Hoon. Similar to Markdown."
 
 +++
 
-**Sail** is a domain specific language for Hoon.
+**Udon** is a domain specific language for Hoon.
 
-Sail is used to create documents, and is very similar to markdown.
+Udon is used to create documents, and is very similar to markdown.


### PR DESCRIPTION
Documentation says Sail but means Udon. See web+urbitgraph://group/~bitbet-bolbel/urbit-community/graph/~darrux-landes/development/170141184505960789598451042477890600960