### PR TITLE
update clay types, tasks and scry endpoints

### DIFF
--- a/content/reference/arvo/clay/data-types.md
+++ b/content/reference/arvo/clay/data-types.md
@@ -6,120 +6,34 @@ weight = 4
 This section will be reference documentation for the data types used by our
 filesystem.
 
-As a general guide, we recommend reading and attempting to understand the data
-structures used in any Hoon code before you try to read the code itself.
-Although complete understanding of the data structures is impossible without
-seeing them used in the code, an 80% understanding greatly clarifies the code.
-As another general guide, when reading Hoon, it rarely pays off to understand
-every line of code when it appears. Try to get the gist of it, and then move on.
-The next time you come back to it, it'll likely make a lot more sense.
+## Internal types
 
-## Data Models
+These types are only used inside of Clay. These are only relevant if you're
+working directly on Clay itself, or trying to understand its inner workings.
 
-As you're reading through this section, remember you can always come
-back to this when you run into these types later on. You're not going to
-remember everything the first time through, but it is worth reading, or
-at least skimming, this so that you get a rough idea of how our state is
-organized.
+### `$cane`
 
-The types that are certainly worth reading are `++raft`, `++room`,
-`++dome:clay`, `++ankh:clay`, `++rung:clay`, `++rang:clay`, `++blob:clay`,
-`++yaki:clay`, and `++nori:clay` (possibly in that order). All in all, though,
-this section isn't too long, so many readers may wish to quickly read through
-all of it. If you get bored, though, just skip to the next section. You can
-always come back when you need to.
-
-## `$raft`
-
-Formal state
+The set of changes between the mergebase and one of the desks being merged.
 
 ```hoon
-+$  raft                                                ::  filesystem
-  $:  rom=room                                          ::  domestic
-      hoy=(map ship rung)                               ::  foreign
-      ran=rang                                          ::  hashes
-      mon=(map term beam)                               ::  mount points
-      hez=(unit duct)                                   ::  sync duct
-      cez=(map @ta crew)                                ::  permission groups
-      pud=(unit [=desk =yoki])                          ::  pending update
-  ==                                                    ::
-```
-
-This is the state of the vane. Anything that must be remembered between
-calls to Clay is stored in this state.
-
-`ran` is the store of all commits and deltas, keyed by hash. The is
-where all the "real" data we know is stored; the rest is "just
-bookkeeping".
-
-`rom` is the state for all local desks. It consists of a `duct` to
-[Dill](/reference/arvo/dill/dill) and a collection of `desk`s.
-
-`hoy` is the state for all foreign desks.
-
-`ran` is the global, hash-addressed object store. It has maps of commit hashes
-to commits and content hashes to content.
-
-`mon` is a collection of Unix mount points. `term` is the mount point (relative
-to th pier) and `beam` is a domestic Clay directory.
-
-`hez` is the duct used to sync with Unix.
-
-`cez` is a collection of named permission groups.
-
-`pud` is an update that's waiting on a kernel upgrade.
-
-## `$room`
-
-Filesystem per domestic ship
-
-```hoon
-+$  room                                                ::  fs per ship
-          $:  hun=duct                                  ::  terminal duct
-              dos=(map desk dojo)                       ::  native desk
-          ==                                            ::
-```
-
-This is the representation of the filesystem of a ship on our pier.
-
-`hun` is the duct we use to send messages to [Dill](/reference/arvo/dill/dill) to
-display notifications of filesystem changes. Only `%note` `%gift`s should be
-produced along this `duct`. This is set by the `%init` `move`.
-
-`dos` is a well-known operating system released in 1981. It is also the
-set of `desk`s on this ship, mapped to their `desk` state.
-
-## `$desk`
-
-Filesystem branch
-
-```hoon
-+$  desk  @tas
-```
-
-This is the name of a branch of the filesystem. The default `desk`s are `%base`, `%garden`, `%landscape`, `%webterm` and `%bitcoin`. Desks have
-independent histories and states, and they may be
-[merged](/reference/arvo/clay/using#merging) into each other.
-
-## `$dojo`
-
-Domestic desk state
-
-```hoon
-+$  dojo
-  $:  qyx=cult                                          ::  subscribers
-      dom=dome                                          ::  desk state
-      per=regs                                          ::  read perms per path
-      pew=regs                                          ::  write perms per path
++$  cane
+  $:  new=(map path lobe)
+      cal=(map path lobe)
+      can=(map path cage)
+      old=(map path ~)
   ==
 ```
 
-This is the all the data that is specific to a particular `desk` on a domestic
-ship. `qyx` is the set of subscribers to this `desk`, and `dom` is the data in
-the `desk`. `regs` are `(map path rule)`, and so `per` is a `map` of read
-permissions by `path` and `pew` is a `map` of write permissions by `path`.
+- `new` is the set of files in the new desk and not in the mergebase.
+- `cal` is the set of changes in the new desk from the mergebase except for any
+  that are also in the other new desk.
+- `can` is the set of changes in the new desk from the mergebase and that are
+  also in the other new desk (potential conflicts).
+- `old` is the set of files in the mergebase and not in the new desk.
 
-## `$cult`
+---
+
+### `$cult`
 
 Subscriptions
 
@@ -127,11 +41,899 @@ Subscriptions
 +$  cult  (jug wove duct)
 ```
 
-`cult`s keep track of subscribers. `wove`s are associated to requests, and each
-`wove` is mapped to a set of `duct`s associated to subscribers who should be
-notified when the request is filled/updated.
+`cult`s keep track of subscribers. [`$wove`](#wove)s are associated to requests,
+and each `wove` is mapped to a set of `duct`s associated to subscribers who
+should be notified when the request is filled/updated.
 
-## `$rave:clay`
+---
+
+### `$melt`
+
+State for ongoing `%fuse` merges.
+
+```hoon
++$  melt  [bas=beak con=(list [beak germ]) sto=(map beak (unit dome:clay))]
+```
+
+- `con` maintains the ordering.
+- `sto` stores the data needed to merge.
+- `bas` is the base `beak` for the merge.
+
+---
+
+### `$dojo`
+
+Domestic desk state
+
+```hoon
++$  dojo
+  $:  qyx=cult                        ::  subscribers
+      dom=dome                        ::  desk state
+      per=regs                        ::  read perms per path
+      pew=regs                        ::  write perms per path
+      fiz=melt                        ::  state for mega merges
+  ==
+```
+
+This is the all the data that is specific to a particular `desk` on a domestic
+ship.
+
+- `qyx` is the set of subscribers to this `desk`.
+- `dom` is the data in the `desk`.
+- `per` is a `map` of read permissions by path.
+- `pew` is a `map` of write permissions by path.
+- `fiz` is the state for ongoing `%fuse` merges.
+
+---
+
+### `$dome`
+
+Desk data
+
+```hoon
++$  dome
+  $:  let=aeon                                          ::  top id
+      hit=(map aeon tako)                               ::  versions by id
+      lab=(map @tas aeon)                               ::  labels
+      tom=(map tako norm)                               ::  tomb policies
+      nor=norm                                          ::  default policy
+      mim=(map path mime)                               ::  mime cache
+      fod=flue                                          ::  ford cache
+      wic=(map weft yoki)                               ::  commit-in-waiting
+      liv=zest                                          ::  running agents
+      ren=rein                                          ::  force agents on/off
+  ==                                                    ::
+```
+
+A `dome` is the state of a `desk` and associated data.
+
+- `let` is the number of the most recently numbered commit. This is also the
+  total number of numbered commits.
+- `hit` is a map of numerical IDs to commit hashes. These hashes are mapped into
+  their associated commits in the [`$rang`](#rang) of the the [`$raft`](#raft)
+  of Clay. In general, the keys of this map are exactly the numbers from 1 to
+  `let`, with no gaps. Of course, when there are no numbered commits, `let` is
+  0, so `hit` is null. Additionally, each of the commits is an ancestor of every
+  commit numbered greater than this one. Thus, each is a descendant of every
+  commit numbered less than this one. Since it is true that the date in each
+  commit (`t.yaki`) is no earlier than that of each of its parents, the numbered
+  commits are totally ordered in the same way by both pedigree and date. If that
+  sounds too complicated to you, don't worry about it. It basically behaves
+  exactly as you would expect.
+- `lab` is a map of textual labels to numbered commits. Labels must be unique
+  across a desk.
+- `tom` contains the tombstoning policies for all files in the desk.
+- `nor` is the default tombstoning policy.
+- `mim` is a cache of the content in the directories that are mounted to Unix.
+- `fod` is the Ford cache, which keeps a cache of the results of builds
+  performed at this `desk`'s current revision, including a full transitive
+  closure of dependencies for each completed build.
+- `wic` contains commits waiting for future kernel versions.
+- `liv` says whether agents on the desk are running or suspended.
+- `ren` records which agents have been forced on or off, differing from the
+  desk's `desk.bill` manifest.
+  
+---
+
+### `$flow`
+
+Global Ford cache
+
+```hoon
++$  flow  (map leak [refs=@ud =soak])
+```
+
+Refcount includes references from other items in the cache, and from `spill`s in
+each desk.
+
+This is optimized for minimizing the number of rebuilds, and given that,
+minimizing the amount of memory used. It is relatively slow to lookup, because
+generating a cache key can be fairly slow (for files, it requires parsing; for
+`tube`s, it even requires building the marks).
+
+---
+
+### `$flue`
+
+Per-desk build cache
+
+```hoon
++$  flue  [spill=(set leak) sprig=(map mist [=leak =soak])]
+```
+
+- `spill` is the set of "roots" we have into the [global ford cache](#flow). We
+  add a root for everything referenced directly or indirectly on a desk, then
+  invalidate them on commit only if their dependencies change.
+- `sprig` is a fast-lookup index over the global ford cache. The only goal is to
+  make cache hits fast.
+
+---
+
+### `$mist`
+
+Ford build without content
+
+```hoon
++$  mist
+  $%  [%file =path]
+      [%nave =mark]
+      [%dais =mark]
+      [%cast =mars]
+      [%tube =mars]
+      [%vale =path]
+      [%arch =path]
+  ==
+```
+
+This is used at the index of `sprig`s in [`$flue`](#flue)s.
+
+---
+
+### `$pour`
+
+Ford build with content.
+
+```hoon
++$  pour
+  $%  [%file =path]
+      [%nave =mark]
+      [%dais =mark]
+      [%cast =mars]
+      [%tube =mars]
+      ::  leafs
+      ::
+      [%vale =path =lobe]
+      [%arch =path =(map path lobe)]
+  ==
+```
+
+Like a [`$mist`](#mist) except the leaf nodes (files and directories) contain
+the [`$lobe:clay`](#lobeclay) (content hash).
+
+---
+
+### `$soak`
+
+Ford result
+
+```hoon
++$  soak
+  $%  [%cage =cage]
+      [%vase =vase]
+      [%arch dir=(map @ta vase)]
+      [%dais =dais]
+      [%tube =tube]
+  ==
+```
+
+The actual data in the Ford cache.
+
+---
+
+### `$leak`
+
+Ford cache key
+
+```hoon
++$  leak
+  $~  [*pour ~]
+  $:  =pour
+      deps=(set leak)
+  ==
+```
+
+This includes all build inputs, including transitive dependencies, recursively.
+
+---
+
+### `$nako`
+
+New desk data
+
+```hoon
++$  nako                                                ::  subscription state
+  $:  gar=(map aeon tako)                               ::  new ids
+      let=aeon                                          ::  next id
+      lar=(set yaki)                                    ::  new commits
+      bar=~                                             ::  new content
+  ==                                                    ::
+```
+
+Sent to other ships to update them about a particular desk. Includes a map of
+all new aeons to hashes of their commits, the most recent aeon, and sets of all
+new commits and data. `bar` is always empty now because we expect you to request
+any data you don't have yet.
+
+---
+
+### `$raft`
+
+Formal state
+
+```hoon
++$  raft                                    ::  filesystem
+  $:  rom=room                              ::  domestic
+      hoy=(map ship rung)                   ::  foreign
+      ran=rang                              ::  hashes
+      fad=flow                              ::  ford cache
+      mon=(map term beam)                   ::  mount points
+      hez=(unit duct)                       ::  sync duct
+      cez=(map @ta crew)                    ::  permission groups
+      tyr=(set duct)                        ::  app subs
+      tur=rock:tire                         ::  last tire
+      pud=(unit [=desk =yoki])              ::  pending update
+      bug=[veb=@ mas=@]                     ::  verbosity
+  ==                                        ::
+```
+
+This is the state of the vane. Anything that must be remembered between
+calls to Clay is stored in this state.
+
+- `rom`: the state for all local desks. It consists of a `duct` to
+  [Dill](/reference/arvo/dill/dill) and a collection of `desk`s.
+- `hoy`: the state for all foreign desks.
+- `ran`: the global, hash-addressed object store. It has maps of commit hashes
+  to commits and content hashes to content.
+- `fad`: the global build cache. Each desk has its own fast-lookup index over
+  this global cache.
+- `mon`: a collection of Unix mount points. `term` is the mount point
+  (relative to th pier) and `beam` is a domestic Clay directory.
+- `hez`: the duct used to sync with Unix.
+- `cez`: a collection of named aermission groups.
+- `tyr`: app subscriptions.
+- `tur`: records whether apps are running and which kernel versions they're
+  compatible with.
+- `pud`: an update that's waiting on a kernel upgrade.
+- `bug`: sets Clay's verbosity.
+
+---
+
+### `$rand`
+
+Unvalidated response to a request.
+
+```hoon
++$  rand                                                ::  unvalidated rant
+          $:  p=[p=care q=case r=@tas]                  ::  clade release book
+              q=path                                    ::  spur
+              r=page                                    ::  data
+          ==                                            ::
+```
+
+Like a [`$rant`](#rant), but with a page of data rather than a cage of it.
+
+---
+
+### `$rede`
+
+Generic desk state
+
+```hoon
++$  rede                                                ::  universal project
+          $:  lim=@da                                   ::  complete to
+              ref=(unit rind)                           ::  outgoing requests
+              qyx=cult                                  ::  subscribers
+              dom=dome                                  ::  revision state
+              per=regs                                  ::  read perms per path
+              pew=regs                                  ::  write perms per path
+              fiz=melt                                  ::  domestic mega merges
+          ==                                            ::
+```
+
+This is our knowledge of the state of a desk, either foreign or
+domestic.
+
+- `lim`: the most recent `@da` for which we're confident we have all the
+  information for. For local `desk`s, this is always `now`. For foriegn `desk`s,
+  this is the last time we got a full update from the foreign ship.
+- `ref`: the request manager for the desk. For domestic `desk`s, this is null
+  since we handle requests ourselves. For foreign `desk`s, this keeps track of
+  all pending foriegn requests plus a cache of the responses to previous
+  requests.
+- `qyx`: the `set` of subscriptions to this desk, with listening `duct`s. These
+  subscriptions exist only until they've been filled. For domestic `desk`s, this
+  is simply `qyx:dojo` - all subscribers to the `desk`. For foreign `desk`s this
+  is all the subscribers from our ship to the foreign `desk`.
+- `dom`: the data in the `desk`.
+- `per`: a `map` of read permissions by path.
+- `pew`: a `map` of write permissions by path.
+- `fiz`: the state for ongoing `%fuse` merges.
+
+---
+
+### `$rind`
+
+Foreign request manager
+
+```hoon
++$  rind                                                ::  request manager
+  $:  nix=@ud                                           ::  request index
+      bom=(map @ud update-state)                        ::  outstanding
+      fod=(map duct @ud)                                ::  current requests
+      haw=(map mood (unit cage))                        ::  simple cache
+  ==                                                    ::
+```
+
+When we send a request to a foreign ship, we keep track of it in here.
+
+- `nix`: request counter.
+- `bom`: a `map` of request numbers to requests.
+- `fod`: reverse `map` of requesters to request numbers.
+- `haw`: a simple cache of common `%sing` requests.
+
+---
+
+### `$bill`
+
+The list of agents that should be automatically started on a desk
+
+```hoon
++$  bill  (list dude:gall)
+```
+
+### `$update-state`
+
+State of outstanding foreign request
+
+```hoon
++$  update-state
+  $:  =duct
+      =rave
+      need=(list lobe)
+      nako=(qeu (unit nako))
+      busy=_|
+  ==
+```
+
+An `update-state` is used to represent the status of an outstanding request to a
+foreign `desk`.
+
+- `duct`: the duct along which the request was made.
+- `rave`: the request itself.
+- `need`: a list of hashes yet to be acquired.
+- `nako`: a queue of data yet to be validated.
+- `busy`: tracks whether or not the request is currently being fulfilled.
+
+---
+
+### `$room`
+
+Filesystem per domestic ship
+
+```hoon
++$  room                                         ::  fs per ship
+          $:  hun=duct                           ::  terminal duct
+              dos=(map desk dojo)                ::  native desk
+          ==                                     ::
+```
+
+This is the representation of the filesystem of a ship on our pier.
+
+- `hun`: the duct we use to send messages to [Dill](/reference/arvo/dill/dill)
+  to display notifications of filesystem changes. Only `%note` `%gift`s should
+  be produced along this `duct`. This is set by the `%init` `move`.
+- `dos`: the set of `desk`s on this ship, mapped to their `desk` state.
+
+---
+
+### `$cach`
+
+Cached result of a request
+
+```hoon
++$  cach  (unit (unit cage))                            ::  cached result
+```
+
+---
+
+### `$wove`
+
+Stored source and request
+
+```hoon
++$  wove  [for=(unit [=ship ver=@ud]) =rove]          ::  stored source + req
+```
+ 
+---
+
+### `$rove`
+
+Stored request
+
+```hoon
++$  rove                                                ::  stored request
+          $%  [%sing =mood]                             ::  single request
+              [%next =mood aeon=(unit aeon) =cach]      ::  next version of one
+              $:  %mult                                 ::  next version of any
+                  =mool                                 ::  original request
+                  aeon=(unit aeon)                      ::  checking for change
+                  old-cach=(map [=care =path] cach)     ::  old version
+                  new-cach=(map [=care =path] cach)     ::  new version
+              ==                                        ::
+              [%many track=? =moat lobes=(map path lobe)] ::  change range
+          ==                                            ::
+```
+
+Like a [`$rave:clay`](#raveclay) but with caches of current versions for `%next`
+and `%many`. Generally used when we store a request in our state somewhere.
+
+---
+
+### `$rung`
+
+Foreign desk data
+
+```hoon
++$  rung
+          $:  rus=(map desk rede)                       ::  neighbor desks
+          ==
+```
+
+This contains the filesystem of a neighbour ship. The keys to this `map` are all
+the `desk`s we know about on their ship.
+
+---
+
+## External types
+
+These types are defined in `lull.hoon`, and are used in Clay's external
+interface.
+
+### `$aeon:clay`
+
+Desk revision number
+
+```hoon
++$  aeon  @ud                                         ::  version number
+```
+
+---
+
+### `$beam:clay`
+
+Global name
+
+```hoon
++$  beam  [[p=ship q=desk r=case] s=path]             ::  global name
+```
+
+The full path to a file or directory.
+
+---
+
+### `$beak:clay`
+
+Path prefix
+
+```hoon
++$  beak  [p=ship q=desk r=case]                      ::  path prefix
+```
+
+A [`$beam:clay`](#beamclay) sans the specific file path.
+
+---
+
+### `$cable:clay`
+
+`/lib`, `/sur` or `mark` reference
+
+```hoon
++$  cable                                             ::  lib/sur/mark ref
+  $:  face=(unit term)                                ::
+      file-path=term                                  ::
+  ==                                                  ::
+```
+
+---
+
+### `$care:clay`
+
+Clay submodule
+
+```hoon
+  +$  care                                              ::  clay submode
+    ?(%a %b %c %d %e %f %p %r %s %t %u %v %w %x %y %z)  ::
+```
+
+This specifies what type of information is requested in a subscription
+or a scry.
+
+- `%a`: build a Hoon file at a `path`.
+- `%b`: build a dynamically typed `mark` by name (a `$dais` mark-interface
+  core).
+- `%c`: build a dynamically typed `mark` conversion gate (a `$tube`) by "from"
+  and "to" `mark` names.
+- `%d`: returns a `(set desk)` of the `desk`s that exist on your ship.
+- `%e`: builds a statically typed `mark` by name (a `$nave` mark-interface
+  core).
+- `%f`: builds a statically typed mark converstion gate.
+- `%p`: produces the permissions for a directory, returned as a `[dict:clay
+  dict:clay]`.
+- `%r`: requests the file in the same fashion as `%x`, but wraps the result in a
+  `vase`.
+- `%s`: has miscellaneous debug endpoints.
+- `%t`: produces a `(list path)` of descendent `path`s for a directory within a
+  `yaki`.
+- `%u`: produces a `?` depending on whether or not the specified file exists. It
+  does not check any of its children.
+- `%v`: requests the entire `dome` for a specified `desk` at a particular
+  `aeon`. When used on a foreign `desk`, this get us up-to-date to the requested
+  version.
+- `%w`: requests the revision number and date of the specified path, returned as
+  a `cass:clay`.
+- `%x`: requests the file at a specified path at the specified commit, returned
+  as an `@`. If there is no node at that path or if the node has no contents
+  (that is, if `fil:ankh` is null), then this crashes.
+- `%y`: requests an `arch` of the specfied commit at the specified path. It will
+  return the bunt of an `arch` if the file or directory is not found.
+- `%z`: requests a recursive hash of a node and all its children, returned as a
+  `@uxI`.
+
+See the [scry reference](/reference/arvo/clay/scry) for more details.
+
+---
+
+### `$case:clay`
+
+Revision reference
+
+```hoon
++$  case                                              ::  ship desk case spur
+  $%  [%da p=@da]                                     ::  date
+      [%tas p=@tas]                                   ::  label
+      [%ud p=@ud]                                     ::  number
+  ==                                                  ::
+```
+
+A commit can be referred to in up to three ways:
+
+- `%da`: commit date
+- `%tas`: label (seldom used currently)
+- `%ud`: sequential revision number
+
+---
+
+### `$cash:clay`
+
+`case` or `tako`
+
+```hoon
++$  cash                                              ::  case or tako
+  $%  [%tako p=tako]                                  ::
+      case                                            ::
+  ==                                                  ::
+```
+
+---
+
+### `$cass:clay`
+
+Cases for revision
+
+```hoon
++$  cass  [ud=@ud da=@da]                             ::  cases for revision
+```
+
+This is returned by a `%w` read.
+
+---
+
+### `$clue:clay`
+
+Tombstone target
+
+```hoon
++$  clue                                              ::  murder weapon
+  $%  [%lobe =lobe]                                   ::  specific lobe
+      [%all ~]                                        ::  all safe targets
+      [%pick ~]                                       ::  collect garbage
+      [%norm =ship =desk =norm]                       ::  set default norm
+      [%worn =ship =desk =tako =norm]                 ::  set commit norm
+      [%seek =ship =desk =cash]                       ::  fetch source blobs
+  ==                                                  ::
+```
+
+---
+
+### `$cone:clay`
+
+Domes
+
+```hoon
++$  cone  (map [ship desk] foam)                      ::  domes
+```
+
+---
+
+### `$foam:clay`
+
+Desk state with additional metadata
+
+```hoon
++$  foam
+  $:  dome
+      tom=(map tako norm)
+      nor=norm
+      liv=zest
+      ren=(map dude:gall ?)
+  ==
+```
+
+- `dome`: desk state
+- `tom`: specific tombstone policies
+- `nor`: default tombstone policy
+- `liv`: agent activation status
+- `ren`: `%rein`'d agents (forced on/off)
+
+---
+
+### `$crew:clay`
+
+Permission group
+
+```hoon
++$  crew  (set ship)                                  ::  permissions group
+```
+
+---
+
+### `$dict:clay`
+
+Effective permission
+
+```hoon
+  +$  dict  [src=path rul=real]                         ::  effective permission
+
+```
+
+---
+
+### `$dome:clay`
+
+```hoon
++$  dome                                              ::  project state
+  $:  let=@ud                                         ::  top id
+      hit=(map @ud tako)                              ::  changes by id
+      lab=(map @tas @ud)                              ::  labels
+  ==                                                  ::
+```
+
+- `let`: current revision number
+- `hit`: map of revisions to their commit hashes
+- `lab`: map of labels to their revision numbers
+
+---
+
+### `$germ:clay`
+
+Merge strategy
+
+```hoon
++$  germ                                              ::  merge style
+  $?  %init                                           ::  new desk
+      %fine                                           ::  fast forward
+      %meet                                           ::  orthogonal files
+      %mate                                           ::  orthogonal changes
+      %meld                                           ::  force merge
+      %only-this                                      ::  ours with parents
+      %only-that                                      ::  hers with parents
+      %take-this                                      ::  ours unless absent
+      %take-that                                      ::  hers unless absent
+      %meet-this                                      ::  ours if conflict
+      %meet-that                                      ::  hers if conflict
+  ==                                                  ::
+```
+
+See the [Strategies](/reference/arvo/clay/using#strategies) section of "Using
+Clay" for further details of their meaning.
+
+---
+
+### `$lobe:clay`
+
+File reference
+
+```hoon
++$  lobe  @uvI                                        ::  blob ref
+```
+
+This is a hash of a [`page`](#pageclay). These are most notably used in
+[`lat.rang`](#rangclay), where they are associated with the actual `page`, and
+as the values in [`q.yaki`](#yakiclay), where `path`s are associated with their
+content hashes in a commit.
+
+---
+
+### `$miso:clay`
+
+File delta
+
+```hoon
++$  miso                                              ::  file delta
+  $%  [%del ~]                                        ::  delete
+      [%ins p=cage]                                   ::  insert
+      [%dif p=cage]                                   ::  mutate from diff
+      [%mut p=cage]                                   ::  mutate from raw
+  ==                                                  ::
+```
+
+There are four kinds of changes that may be made to a node in a `desk`.
+
+- `%del`: deletes the node.
+- `%ins`: inserts a file given by `p`.
+- `%dif`: currently unimplemented. This may seem strange, so we remark that
+  diffs for individual files are implemented using `+diff` and `+pact` in
+  `mark`s. So for an `ankh`, which may include both files and directories,
+  `%dif` being unimplemented really just means that we do not yet have a formal
+  concept of changes in directory structure.
+- `%mut`: mutates the file using raw data given by `p`.
+
+---
+
+### `$moar:clay`
+
+Normal change range
+
+```hoon
++$  moar  [p=@ud q=@ud]                               ::  normal change range
+```
+
+---
+
+### `$moat:clay`
+
+Range subscription request
+
+```hoon
++$  moat  [from=case to=case =path]                   ::  change range
+```
+
+This represents a request for all changes between `from` and `to` on `path`. You
+will be notified when a change is made to the node referenced by the `path` or
+to any of its children.
+
+---
+
+### `$mode:clay`
+
+External files
+
+```hoon
++$  mode  (list [path (unit mime)])                   ::  external files
+```
+
+This is used when there's a commit from the host system.
+
+---
+
+### `$mood:clay`
+
+Single subscription request
+
+```hoon
++$  mood  [=care =case =path]                         ::  request in desk
+```
+
+This represents a request for data related to the state of the `desk` at a
+particular commit, specfied by `case`. The `care` specifies what kind of
+information is desired, and the `path` specifies the path we are requesting.
+
+---
+
+### `$nori:clay`
+
+Repository action
+
+```hoon
++$  nori                                              ::  repository action
+  $%  [%& p=soba]                                     ::  delta
+      [%| p=@tas q=(unit aeon)]                       ::  label
+  ==                                                  ::
+```
+
+This describes a change that we are asking Clay to make to the `desk`. There are
+two kinds of changes that may be made: we can modify files or we can apply a
+label to a commit.
+
+In the `&` case, we will apply the given changes. In the `|` case, we will apply
+the given label to the commit specified in `q`, or the current one if it's null.
+
+---
+
+### `$norm:clay`
+
+Tombstone policy.
+
+```hoon
++$  norm  (axal ?)
+```
+
+An `axal` is a recursive directory structure. For each file, a `?` says whether
+it should be tombstoned or not.
+
+---
+
+### `$page:clay`
+
+A raw, unvalidated file.
+
+```hoon
++$  page  ^page                                       ::  export for compat
+```
+
+This is just the `page` defined in `arvo.hoon`: a pair of a mark and a noun.
+
+---
+
+### `$rang:clay`
+
+Data repository
+
+```hoon
++$  rang                                              ::  repository
+  $:  hut=(map tako yaki)                             ::  changes
+      lat=(map lobe page)                             ::  data
+  ==                                                  ::
+```
+
+This is a data repository keyed by hash. Thus, this is where the "real" data is
+stored, but it is only meaningful if we know the hash of what we're looking for.
+
+`hut` is a `map` from commit hashes ([`tako`](#takoclay)s) to commits
+([`yaki`](#yakiclay)s). We often get the hashes from [`hit.dome`](#domeclay),
+which keys them by numerical id.
+
+`lat` is a `map` from content hashes ([`lobe`](#lobeclay)s) to the actual
+content ([`page`](#pageclay)s). We often get the hashes from a
+[`yaki`](#yakiclay), which references this `map` to get the data. There is no
+`page` in `yaki:clay`. They are only accessible through `lat`.
+
+---
+
+### `$rant:clay`
+
+Response data
+
+```hoon
++$  rant                                              ::  response to request
+  $:  p=[p=care q=case r=desk]                        ::  clade release book
+      q=path                                          ::  spur
+      r=cage                                          ::  data
+  ==                                                  ::
+```
+
+This is the data associated to the response to a request.
+
+- `p.p`: specifies the type of data that was requested (and is produced).
+- `q.p`: gives the specific version reported (since a range of versions may be
+  requested in a subscription).
+- `r.p`: the `desk`.
+- `q`: the path to the filesystem node.
+- `r`: is the data itself (in the format specified by `p.p`).
+
+---
+
+### `$rave:clay`
 
 General subscription request
 
@@ -146,453 +948,149 @@ General subscription request
 
 This represents a subscription request for a `desk`.
 
-A `%sing` request asks for data at single revision.
+- `%sing`: asks for data at single revision.
 
-A `%next` request asks to be notified the next time there’s a change to the
-specified file.
+- `%next`: asks to be notified the next time there’s a change to the specified
+  file.
+- `%mult`: asks to be notified the next time there's a change to a specified set
+  of files.
+- `%many`: asks to be notified on every change in a `desk` for a range of
+  changes (including into the future).
 
-A `%mult` request asks to be notified the next time there's a change to a
-specified set of files.
+---
 
-A `%many` request asks to be notified on every change in a `desk` for a range of changes (including into the future).
+### `$real:clay`
 
-## `$rove`
-
-Stored general subscription request
-
-```hoon
-+$  rove                                                ::  stored request
-      $%  [%sing =mood]                                 ::  single request
-          [%next =mood aeon=(unit aeon) =cach]          ::  next version of one
-          $:  %mult                                     ::  next version of any
-              =mool                                     ::  original request
-              aeon=(unit aeon)                          ::  checking for change
-              old-cach=(map [=care =path] cach)         ::  old version
-              new-cach=(map [=care =path] cach)         ::  new version
-          ==                                            ::
-          [%many track=? =moat lobes=(map path lobe)]   ::  change range
-      ==                                                ::
-```
-
-Like a `rave` but with provisions to store current versions for `%next` and `%many`.
-Generally used when we store a request in our state somewhere. This is so that
-we can determine whether new versions actually affect the path we're subscribed to.
-
-## `$mood:clay`
-
-Single subscription request
+Resolved permissions
 
 ```hoon
-+$  mood  [=care =case =path]                         ::  request in desk
-```
-
-This represents a request for data related to the state of the `desk` at a
-particular commit, specfied by `case`. `care` specifies what kind of information
-is desired, and `path` specifies the path we are requesting.
-
-## `$moat:clay`
-
-Range subscription request
-
-```hoon
-+$  moat  [from=case to=case =path]                   ::  change range
-```
-
-This represents a request for all changes between `from` and `to` on `path`. You
-will be notified when a change is made to the node referenced by the `path` or to
-any of its children.
-
-## `$care:clay`
-
-Clay submode
-
-```hoon
-+$  care  ?(%a %b %c %d %e %f %p %r %s %t %u %v %w %x %y %z)  ::  clay submode
-```
-
-This specifies what type of information is requested in a subscription
-or a scry.
-
-`%a` build a Hoon file at a `path`.
-
-`%b` build a dynamically typed `mark` by name (a `$dais` mark-interface core).
-
-`%c` build a dynamically typed `mark` conversion gate (a `$tube`) by "from" and
-"to" `mark` names.
-
-`%d` returns a `(set desk)` of the `desk`s that exist on your ship.
-
-`%e` builds a statically typed `mark` by name (a `$nave` mark-interface core).
-
-`%f` builds a statically typed mark converstion gate.
-
-`%p` produces the permissions for a directory, returned as a `[dict:clay dict:clay]`.
-
-`%r` requests the file in the same fashion as `%x`, but wraps the result in a `vase`.
-
-`%s` has miscellaneous debug endpoints.
-
-`%t` produces a `(list path)` of descendent `path`s for a directory within a `yaki`.
-
-`%u` produces a `?` depending on whether or not the specified file exists. It
-does not check any of its children.
-
-`%v` requests the entire `dome` for a specified `desk` at a particular `aeon`.
-When used on a foreign `desk`, this get us up-to-date to the requested version.
-
-`%w` requests the revision number and date of the specified path, returned as a `cass:clay`.
-
-`%x` requests the file at a specified path at the specified commit, returned as
-an `@`. If there is no node at that path or if the node has no contents (that
-is, if `fil:ankh` is null), then this crashes.
-
-`%y` requests an `arch` of the specfied commit at the specified path. It will
-return the bunt of an `arch` if the file or directory is not found.
-
-`%z` requests a recursive hash of a node and all its children, returned as a `@uxI`.
-
-## `$ankh`
-
-Filesystem node
-
-```hoon
-+$  ankh                                                ::  expanded node
-  $~  [~ ~]
-  $:  fil=(unit [p=lobe q=cage])                        ::  file
-      dir=(map @ta ankh)                                ::  folders
-  ==                                                    ::
-```
-
-This is a recursive filesystem node type that can describe a whole tree of
-folders and files, with subtrees organized by path prefix. In Earth filesystems,
-a node is a file xor a directory. On Mars, we're inclusive, so a node is a file
-ior a directory.
-
-`fil` is the contents of this file, if any. `p.fil` is a hash of the
-contents while `q.fil` is the data itself.
-
-`dir` is the set of children of this node. In the case of a pure file,
-this is empty. The keys are the names of the children and the values
-are, recursively, the nodes themselves.
-
-## `$arch`
-
-Shallow filesystem node
-
-```hoon
-+$  arch  (axil @uvI)
-++  axil
-  |$  [item]
-  [fil=(unit item) dir=(map @ta ~)]
-```
-
-An `arch` is a lightweight version of an `ankh` that only contains the hash
-of the associated file and a `map` of child directories, but not the children of
-those directories.
-
-The child directories are given by a `map` to null rather than a `set` so that the
-ordering of the `map` will be the same as it is for an `axal`, allowing
-efficient conversion for when the heavier node is needed.
-
-```hoon
-++  axal
-  |$  [item]
-  [fil=(unit item) dir=(map @ta $)]
-```
-
-## `$case`
-
-Specifying a commit
-
-```hoon
-+$  case
-  $%  ::  %da:  date
-      ::  %tas: label
-      ::  %ud:  sequence
-      ::
-      [%da p=@da]
-      [%tas p=@tas]
-      [%ud p=@ud]
-  ==
-```
-
-A commit can be referred to in three ways: `%da` refers to the commit
-that was at the head on date `p`, `%tas` refers to the commit labeled
-`p`, and `%ud` refers to the commit numbered `p`. Note that since these
-all can be reduced down to a `%ud`, only numbered commits may be
-referenced with a `++case:clay`.
-
-## `$dome`
-
-Desk data
-
-```hoon
-+$  dome
-  $:  ank=ankh                                          ::  state
-      let=aeon                                          ::  top id
-      hit=(map aeon tako)                               ::  versions by id
-      lab=(map @tas aeon)                               ::  labels
-      mim=(map path mime)                               ::  mime cache
-      fod=ford-cache                                    ::  ford cache
-      fer=(unit reef-cache)                             ::  reef cache
-  ==                                                    ::
-```
-
-A `dome` is the state of a `desk` and associated data.
-
-`ank` is the current state of the desk. Thus, it is the state of the
-filesystem at revison `let`. The head of a `desk` is always a numbered
-commit.
-
-`let` is the number of the most recently numbered commit. This is also
-the total number of numbered commits.
-
-`hit` is a map of numerical ids to commit hashes. These hashes are mapped into
-their associated commits in `hut.rang` in the `raft` of Clay. In general, the
-keys of this map are exactly the numbers from 1 to `let`, with no gaps. Of
-course, when there are no numbered commits, `let` is 0, so `hit` is null.
-Additionally, each of the commits is an ancestor of every commit numbered
-greater than this one. Thus, each is a descendant of every commit numbered less
-than this one. Since it is true that the date in each commit (`t:yaki`) is no
-earlier than that of each of its parents, the numbered commits are totally
-ordered in the same way by both pedigree and date. Of course, not every commit
-is numbered. If that sounds too complicated to you, don't worry about it. It
-basically behaves exactly as you would expect.
-
-`lab` is a map of textual labels to numbered commits. Note that labels
-can only be applied to numbered commits. Labels must be unique across a
-desk.
-
-`mim` is a cache of the content in the directories that are mounted to Unix.
-
-`fod` is the Ford cache, which keeps a cache of the results of builds performed
-at this `desk`'s current revision, including a full transitive closure of
-dependencies for each completed build.
-
-`fer` is the system file cache, which consists of `vase`s for `hoon.hoon`,
-`arvo.hoon`, `lull.hoon`, and `zuse.hoon`.
-
-## `$rung`
-
-Filesystem per neighbor ship
-
-```hoon
-+$  rung
-          $:  rus=(map desk rede)                       ::  neighbor desks
-          ==
-```
-
-This is the filesystem of a neighbor ship. The keys to this `map` are all
-the `desk`s we know about on their ship.
-
-## `$rede`
-
-Generic desk state
-
-```hoon
-+$  rede                                                ::  universal project
-          $:  lim=@da                                   ::  complete to
-              ref=(unit rind)                           ::  outgoing requests
-              qyx=cult                                  ::  subscribers
-              dom=dome                                  ::  revision state
-              per=regs                                  ::  read perms per path
-              pew=regs                                  ::  write perms per path
-          ==                                            ::
-```
-
-This is our knowledge of the state of a desk, either foreign or
-domestic.
-
-`lim` is the most recent `@da` for which we're confident we have all the
-information for. For local `desk`s, this is always `now`. For foriegn `desk`s,
-this is the last time we got a full update from the foreign ship.
-
-`ref` is the request manager for the desk. For domestic `desk`s, this is
-null since we handle requests ourselves. For foreign `desk`s, this keeps track
-of all pending foriegn requests plus a cache of the responses to previous requests.
-
-`qyx` is the `set` of subscriptions to this desk, with listening `duct`s. These
-subscriptions exist only until they've been filled. For domestic `desk`s, this
-is simply `qyx:dojo` - all subscribers to the `desk`. For foreign `desk`s this
-is all the subscribers from our ship to the foreign `desk`.
-
-`dom` is the data in the `desk`.
-
-`regs` are `(map path rule)`, and so `per` is a `map` of read permissions by
-`path` and `pew` is a `map` of write permissions by `path`.
-
-## `$rind`
-
-Foreign request manager
-
-```hoon
-+$  rind                                                ::  request manager
-  $:  nix=@ud                                           ::  request index
-      bom=(map @ud update-state)                        ::  outstanding
-      fod=(map duct @ud)                                ::  current requests
-      haw=(map mood (unit cage))                        ::  simple cache
-  ==                                                    ::
-```
-
-This is the request manager for a foreign `desk`. When we send a request to a
-foreign ship, we keep track of it in here.
-
-`nix` is one more than the index of the most recent request. Thus, it is the
-next available request number.
-
-`bom` is the set of outstanding requests. The keys of this `map` are some subset
-of the numbers between 0 and one less than `nix`. The members of the `map` are
-exactly those requests that have not yet been fully satisfied.
-
-`fod` is the same set as `bom`, but from a different perspective. In particular,
-the values of `fod` are the same as the keys of `bom`, and the `duct` of the
-values of `bom` are the same as the keys of `fod`. Thus, we can map `duct`s to
-their associated request number and `update-state`, and we can map request
-numbers to their associated `duct`.
-
-`haw` is a map from `%sing` requests to their values. This acts as a cache for
-requests that have already been filled.
-
-## `$update-state`
-
-Status of outstanding foreign request
-
-```hoon
-+$  update-state
-  $:  =duct
-      =rave
-      have=(map lobe blob)
-      need=(list lobe)
-      nako=(qeu (unit nako))
-      busy=_|
-  ==
-```
-
-An `update-state` is used to represent the status of an outstanding request to a
-foreign `desk`.
-
-`duct` and `rave` are the `duct` along which the request was made and the
-request itself.
-
-`have` is a map of hashes thus far acquired in the request to the data
-associated with those hashes.
-
-`need` is a list of hashes yet to be acquired.
-
-`nako` is a queue of data yet to be validated.
-
-`busy` tracks whether or not the request is currently being fulfilled.
-
-## `$rang:clay`
-
-Data repository
-
-```hoon
-+$  rang                                              ::  repository
-  $:  hut=(map tako yaki)                             ::  changes
-      lat=(map lobe blob)                             ::  data
++$  real                                              ::  resolved permissions
+  $:  mod=?(%black %white)                            ::
+      who=(pair (set ship) (map @ta crew))            ::
   ==                                                  ::
 ```
 
-This is a data repository keyed by hash. Thus, this is where the "real" data
-is stored, but it is only meaningful if we know the hash of what we're
-looking for.
+- `mod`: whether it's a blacklist or whitelist.
+- `who`: the ships who are blacklisted/whitelisted. It can have both individual
+  ships as well as [`crew`](#crewclay) (permission groups).
 
-`hut` is a `map` from commit hashes (`tako`s) to commits (`yaki`s). We often get
-the hashes from `hit:dome`, which keys them by numerical id. Not every commit
-has an numerical id.
+---
 
-`lat` is a `map` from content hashes (`lobe`s) to the actual content (`blob`s).
-We often get the hashes from a `yaki`, which references this `map` to get the
-data. There is no `blob` in `yaki:clay`. They are only accessible through
-`lat`.
+### `$regs:clay`
 
-## `$tako:clay`
+Permission rules for paths
+
+```hoon
++$  regs  (map path rule)                             ::  rules for paths
+```
+
+A map from file/directory paths to permission [`rule`](#ruleclay)s.
+
+---
+
+### `$rein:clay`
+
+Forced on/off apps
+
+```hoon
++$  rein  (map dude:gall ?)                           ::  extra apps
+```
+
+A `dude:gall` is the name of a Gall agent and the `?` is whether it's forced on
+or off. An app is forced when it's started despite not being on the `desk.bill`
+manifest or stopped when it *is* on the manifest.
+
+---
+
+### `$riff:clay`
+
+Request/desist
+
+```hoon
++$  riff  [p=desk q=(unit rave)]                      ::  request+desist
+```
+
+This represents a request for data about a particular `desk`. If `q` contains a
+`rave`, then this opens a subscription to the `desk` for that data. If `q` is
+null, then this tells Clay to cancel the subscription along this duct.
+
+---
+
+### `$rite:clay`
+
+New permissions
+
+```hoon
++$  rite                                              ::  new permissions
+  $%  [%r red=(unit rule)]                            ::  for read
+      [%w wit=(unit rule)]                            ::  for write
+      [%rw red=(unit rule) wit=(unit rule)]           ::  for read and write
+  ==                                                  ::
+```
+
+- `%r`: read permissions.
+- `%w`: write permissions.
+- `%rw`: both read and write permissions.
+
+---
+
+### `$riot:clay`
+
+Response
+
+```hoon
++$  riot  (unit rant)                                 ::  response+complete
+```
+
+A `riot` is a response to a subscription. If null, the subscription has been
+completed, and no more responses will be sent. Otherwise, the `rant` is the
+produced data.
+
+---
+
+### `$rule:clay`
+
+Node permission
+
+```hoon
++$  rule  [mod=?(%black %white) who=(set whom)]       ::  node permission
+```
+
+- `mod`: whether it's a blacklist or whitelist.
+- `who`: the ships or permission groups on the list.
+
+---
+
+### `$soba:clay`
+
+Delta
+
+```hoon
++$  soba  (list [p=path q=miso])                      ::  delta
+```
+
+This describes a `list` of changes to make to a `desk`. The `path`s are `path`s
+to files to be changed, and the corresponding `miso` value is a description of
+the change itself.
+
+---
+
+### `$tako:clay`
 
 Commit reference
 
 ```hoon
-+$  tako  @                                           ::  yaki ref
++$  tako  @uvI                                        ::  yaki ref
 ```
 
-This is a hash of a `yaki:clay`, a commit. These are most notably used as the
-keys in `hut:rang:clay`, where they are associated with the actual `yaki:clay`,
-and as the values in `hit:dome:clay`, where sequential numerical ids are
-associated with these.
+This is a hash of a [`yaki`](#yakiclay), a commit. These are most notably used
+as the keys in [`hut.rang`](#rangclay), where they are associated with the
+actual `yaki`, and as the values in [`hit.dome`](#domeclay), where sequential
+numerical ids are associated with these.
 
-## `$yaki:clay`
+---
 
-Commit
-
-```hoon
-+$  yaki                                              ::  commit
-  $:  p=(list tako)                                   ::  parents
-      q=(map path lobe)                               ::  namespace
-      r=tako                                          ::  self-reference
-      t=@da                                           ::  date
-  ==                                                  ::
-```
-
-This is a single commit.
-
-`p` is a `list` of the hashes of the parents of this commit. In most
-cases, this will be a single commit, but in a merge there may be more
-parents. In theory, there may be an arbitrary number of parents, but in
-practice merges have exactly two parents. This may change in the future.
-For commit 1, there is no parent.
-
-`q` is a `map` of the `path`s on a desk to the content hashes at that location.
-If you understand what a `lobe:clay` and a `blob:clay` is, then the type
-signature here tells the whole story.
-
-`r` is the hash associated with this commit.
-
-`t` is the date at which this commit was made.
-
-## `$lobe:clay`
-
-Data reference
-
-```hoon
-+$  lobe  @uvI                                        ::  blob ref
-```
-
-This is a hash of a `blob:clay`. These are most notably used in `lat:rang:clay`,
-where they are associated with the actual `blob:clay`, and as the values in
-`q:yaki:clay`, where `path`s are associated with their content hashes in a commit.
-
-## `$blob:clay`
-
-Data
-
-```hoon
-+$  blob                                              ::  fs blob
-  $%  [%delta p=lobe q=[p=mark q=lobe] r=page]        ::  delta on q
-      [%direct p=lobe q=page]                         ::  immediate
-```
-
-This is a node of data. In both cases, `p` is the hash of the blob.
-
-`%delta` is the case where we define the data by a delta on other data. In
-practice, the other data is always the previous commit, but nothing depends on
-this. `p.q` is the `mark` of the parent blob, `q.q` is the hash of the parent
-blob, and `r` is the delta.
-
-`%direct` is the case where we simply have the data directly. `q` is the data.
-These almost always come from the creation of a file.
-
-## `+urge`
-
-List change
-
-```hoon
-++  urge  |*(a=mold (list (unce a)))                  ::  list change
-```
-
-This is a parametrized type for list changes. For example, `(urge @t)`
-is a list change for lines of text.
-
-## `+unce`
+### `+unce:clay`
 
 Change part of a list.
 
@@ -607,132 +1105,128 @@ Change part of a list.
 This is a single change in a list of elements of type `a`. For example,
 `(unce @t)` is a single change in lines of text.
 
-`%&` means the next `p` lines are unchanged.
+- `%&`: the next `p` lines are unchanged.
+- `%|`: the lines `p` have changed to `q`.
 
-`%|` means the lines `p` have changed to `q`.
+---
 
-## `$nori:clay`
+### `+urge:clay`
 
-Repository action
+List change
 
 ```hoon
-+$  nori                                              ::  repository action
-  $%  [%& p=soba]                                     ::  delta
-      [%| p=@tas]                                     ::  label
+++  urge  |*(a=mold (list (unce a)))                  ::  list change
+```
+
+This is a parametrized type for list changes. For example, `(urge @t)` is a list
+change for lines of text.
+
+---
+
+### `$waft:clay`
+
+Kelvin range
+
+```hoon
++$  waft                                              ::  kelvin range
+  $^  [[%1 ~] p=(set weft)]                           ::
+  weft                                                ::
+```
+
+A `waft` is the result of reading a `sys.kelvin` file in a desk. It lists all
+the `weft`s (kernel versions) a desk is compatible with. It may
+either be a single `weft` like `[%zuse 417]`, or a range like:
+
+```hoon
+[[%1 ~] (silt zuse+417 zuse+416 ~)]
+```
+
+---
+
+### `$whom:clay`
+
+Ship or named crew
+
+```hoon
++$  whom  (each ship @ta)                             ::  ship or named crew
+```
+
+Either a single ship or a set of ships in a [`crew`](#crewclay) (permission
+group). This is used for read/write permissions.
+
+---
+
+### `$yoki:clay`
+
+Commit
+
+```hoon
+  +$  yoki  (each yuki yaki)                            ::  commit
+```
+
+Either a [`yuki`](#yukiclay) or a [`yaki`](#yakiclay). A `yuki` is a
+proto-commit, a `yaki` is a final commit whose data is entirely in the general
+object store.
+
+---
+
+### `$yuki:clay`
+
+Proto-commit
+
+```hoon
++$  yuki                                              ::  proto-commit
+  $:  p=(list tako)                                   ::  parents
+      q=(map path (each page lobe))                   ::  namespace
   ==                                                  ::
 ```
 
-This describes a change that we are asking Clay to make to the `desk`.
-There are two kinds of changes that may be made: we can modify files or
-we can apply a label to a commit.
+A `yuki` is a proto-commit: a new, proposed commit that has not yet been
+finalized. This is in contrast to a [`yaki`](#yakiclay). The main difference is
+that a `yuki` may contain actual data, while a `yaki` only contains
+[`lobe`](#lobeclay)s ( content hashes used as references to data in the general
+object store).
 
-In the `|` case, we will simply label the current commit with the given
-label. In the `&` case, we will apply the given changes.
+- `p`: commit references of any parents.
+- `q`: a `map` from file paths to either [`page`](#page:clay) data or `lobe`s.
 
-## `$soba:clay`
+---
 
-Delta
+### `$yaki:clay`
 
-```hoon
-+$  soba  (list [p=path q=miso])                      ::  delta
-```
-
-This describes a `list` of changes to make to a `desk`. The `path`s are `path`s
-to files to be changed, and the corresponding `miso` value is a description of
-the change itself.
-
-## `$miso:clay`
-
-Ankh delta
+Finalized commit
 
 ```hoon
-+$  miso                                              ::  ankh delta
-  $%  [%del ~]                                        ::  delete
-      [%ins p=cage]                                   ::  insert
-      [%dif p=cage]                                   ::  mutate from diff
-      [%mut p=cage]                                   ::  mutate from raw
++$  yaki                                              ::  commit
+  $:  p=(list tako)                                   ::  parents
+      q=(map path lobe)                               ::  namespace
+      r=tako                                          ::  self-reference
+      t=@da                                           ::  date
   ==                                                  ::
 ```
 
-There are four kinds of changes that may be made to a node in a `desk`.
+- `p`: a `list` of the hashes of the parents of this commit. In most cases,
+  this will be a single commit, but in a merge there may be more parents.
+- `q`: is a `map` of the `path`s on a desk to the content hashes at that
+  location. If you understand what a [`lobe`](#lobeclay) and a
+  [`page`](#pageclay) is, then the type signature here tells the whole story.
+- `r`: is the hash associated with this commit.
+- `t`: is the date at which this commit was made.
 
-`%del` deletes the node.
+---
 
-`%ins` inserts a file given by `p`.
+### `$zest:clay`
 
-`%dif` is currently unimplemented. This may seem strange, so we remark that
-diffs for individual files are implemented using `+diff` and `+pact` in `mark`s.
-So for an `ankh`, which may include both files and directories, `%dif` being
-unimplemented really just means that we do not yet have a formal concept of
-changes in directory structure.
-
-`%mut` mutates the file using raw data given by `p`.
-
-## `$riff:clay`
-
-Request/desist
+How live
 
 ```hoon
-+$  riff  [p=desk q=(unit rave)]                      ::  request+desist
++$  zest  $~(%dead ?(%dead %live %held))              ::  how live
 ```
 
-This represents a request for data about a particular `desk`. If `q`
-contains a `rave`, then this opens a subscription to the `desk` for that
-data. If `q` is null, then this tells Clay to cancel the subscription
-along this duct.
+This represents the state of apps on the desk.
 
-## `$riot:clay`
+- `%dead`: suspended.
+- `%held`: suspended pending compatible system update.
+- `%live`: running.
 
-Response
-
-```hoon
-+$  riot  (unit rant)                                 ::  response+complete
-```
-
-A `riot` is a response to a subscription. If null, the subscription has
-been completed, and no more responses will be sent. Otherwise, the
-`rant` is the produced data.
-
-## `$rant:clay`
-
-Response data
-
-```hoon
-+$  rant                                              ::  response to request
-  $:  p=[p=care q=case r=desk]                        ::  clade release book
-      q=path                                          ::  spur
-      r=cage                                          ::  data
-  ==                                                  ::
-```
-
-This is the data associated to the response to a request. `p.p` specifies
-the type of data that was requested (and is produced). `q.p` gives the
-specific version reported (since a range of versions may be requested in
-a subscription). `r.p` is the `desk`. `q` is the path to the filesystem
-node. `r` is the data itself (in the format specified by `p.p`).
-
-## `$nako`
-
-Subscription response data
-
-```hoon
-+$  nako                                                ::  subscription state
-  $:  gar=(map aeon tako)                               ::  new ids
-      let=aeon                                          ::  next id
-      lar=(set yaki)                                    ::  new commits
-      bar=(set plop)                                    ::  new content
-  ==                                                    ::
-```
-
-This is the data that is produced by a request for a range of revisions
-of a `desk`. This allows us to easily keep track of a remote repository --
-all the new information we need is contained in the `nako`.
-
-`gar` is a map of the revisions in the range to the hash of the commit
-at that revision. These hashes can be used with `hut:rang:clay` to find the
-commit itself.
-
-`let` is either the last revision number in the range or the most recent
-revision number, whichever is smaller.
-
-`lar` is the set of new commits, and `bar` is the set of new content.
+---

--- a/content/reference/arvo/clay/scry.md
+++ b/content/reference/arvo/clay/scry.md
@@ -339,8 +339,8 @@ it to do a `%s` scry for the `blob:clay` of the file.
 
 ### `%hash` - Commit hash
 
-This will return the `@uvI` content hash of the specified commit. It takes a
-[`tako:clay`](/reference/arvo/clay/data-types#takoclay).
+This will return the `@uvI` (256-bit) content hash of the specified commit. It
+takes a [`tako:clay`](/reference/arvo/clay/data-types#takoclay).
 
 Example:
 

--- a/content/reference/arvo/clay/scry.md
+++ b/content/reference/arvo/clay/scry.md
@@ -3,14 +3,148 @@ title = "Scry Reference"
 weight = 5
 +++
 
-The various Clay scries are specified by a `care`, which is a single character corresponding with a Clay submodule. Apart from `%s` they just take a `path` to a `desk`, file or directory. All examples are dojo commands, the %'s in the path are automatically populated by the dojo like:
+The normal Clay scries are specified by a `care`, which is a single character
+corresponding with a Clay submodule. Apart from `%s` they just take a `path` to
+a `desk`, file or directory. All examples are dojo commands, the %'s in the path
+are automatically populated by the dojo like:
 
 ```
 > %
 [~.~zod ~.base ~.~2021.4.26..02.29.03..d31b ~]
 ```
 
-## %a - Build hoon.
+In addition to the ordinary `care`-based endpoints, there are also a few special
+endpoints described in the [Misc. Queries](#misc-queries) section below.
+
+## Misc. queries
+
+Clay exposes a few special "buc" scry endpoints. These all use a `%x` `care` and
+must have a desk of `%$` (an empty string) in the `beak`. They therefore have
+the basic form of:
+
+```
+.^([return type] %cx /=//=/[path])
+```
+
+Each of the possible `[path]`s are described below.
+
+---
+
+### `/sweep` - Cache check
+
+A buc scry with a path of `/sweep` will check the global ford cache for refcount
+errors. It returns a `(list [need=@ud have=@ud leak])`, where a
+[`leak`](/reference/arvo/clay/data-types#leak) is a Ford cache key used
+internally by Clay.
+
+Example:
+
+```
+> .^((list [need=@ud have=@ud *]) %cx /=//=/sweep)
+~
+```
+
+---
+
+### `/rang` - Get `rang`
+
+A buc scry with a path of `/rang` will return the full
+[`rang`](/reference/arvo/clay/data-types#rangclay) from Clay's state.
+
+Example:
+
+```
+> =ran .^(rang:clay %cx /=//=/rang)
+> ~(wyt by hut.ran)
+31
+```
+
+---
+
+### `/tomb/[path]` - Is accessible?
+
+A buc scry with a path beginning with `/tomb` will return a `?` which is `%.y`
+if the file specified by `[path]` is accessible, and `%.n` otherwise. The
+`[path]` must be a full `beam` like `/~zod/base/12/sys/kelvin`.
+
+Note that `%.n` is returned either if the file has been tombstoned or if it
+doesn't exist at all, so it doubles as a tombstone check and existence check.
+
+Example:
+
+```
+> .^(? %cx /=//=/tomb/(scot %p our)/base/(scot %da now)/sys/kelvin)
+%.y
+```
+
+---
+
+### `/domes` - All domes
+
+A buc scry with a path of `/domes` will return a
+[`cone:clay`](/reference/arvo/clay/data-types#coneclay) containing the `dome`s
+and associated metadata for all desks, foreign and local.
+
+Example:
+
+```
+> =domes .^(cone:clay %cx /=//=/domes)
+> ~(key by domes)
+{ [~zod %landscape]
+  [~mister-dister-dozzod-dozzod %garden]
+  [~lander-dister-dozzod-dozzod %landscape]
+  [~mister-dister-dozzod-dozzod %webterm]
+  [~zod %bitcoin]
+  [~zod %kids]
+  [~zod %garden]
+  [~zod %base]
+  [~zod %webterm]
+  [~mister-dister-dozzod-dozzod %bitcoin]
+}
+```
+
+---
+
+### `/tire` - App state
+
+A buc scry with a path of `/tire` will return the `rock:tire:clay` for all
+domestic desks, which is a `(map desk [=zest wic=(set weft)])`. The
+[`zest`](/reference/arvo/clay/data-types#zestclay) specifies whether apps on the
+desk are running or suspended. The `wic` set contains the `weft`s (kernel
+versions) of any queued updates.
+
+Example:
+
+```
+> .^(rock:tire:clay %cx /=//=/tire)
+{ [p=%bitcoin q=[zest=%live wic={}]]
+  [p=%base q=[zest=%live wic={}]]
+  [p=%landscape q=[zest=%live wic={}]]
+  [p=%webterm q=[zest=%live wic={}]]
+  [p=%garden q=[zest=%live wic={}]]
+  [p=%kids q=[zest=%dead wic={}]]
+}
+```
+
+---
+
+### `/tyre` - App state subs
+
+A buc scry with a path of `/tyre` will return the `(set duct)` of all
+subscriptions to app states (those made via `%tire` tasks).
+
+Example:
+
+```
+> .^((set duct) %cx /=//=/tyre)
+{ ~[/gall/use/hark-system-hook/0w2.k8ns8/~zod/clay/tire /dill //term/1]
+  ~[/gall/use/docket/0w2.k8ns8/~zod/tire /dill //term/1]
+}
+```
+
+---
+
+## `%a` - Build hoon
 
 A scry with a `care` of `%a` will build a `hoon` file and return it as a `vase`.
 
@@ -20,9 +154,12 @@ Example:
 .^(vase %ca %/lib/strandio/hoon)
 ```
 
-## %b - Dyn. mark core.
+---
 
-A scry with a `care` of `%b` will produce a `dais:clay` processed `mark` core for the specified `mark`. The `path` in the scry is a `mark`.
+## `%b` - Dyn. mark core.
+
+A scry with a `care` of `%b` will produce a `dais:clay` processed `mark` core
+for the specified `mark`. The `path` in the scry is a `mark`.
 
 Example:
 
@@ -32,7 +169,9 @@ Example:
 
 ## %c - Dyn. mark convert.
 
-A scry with a `care` of `%c` will produce a `tube:clay` dynamically typed `mark` conversion gate. The `path` specifies two `mark`s - _from_ and _to_, like `/txt/noun`.
+A scry with a `care` of `%c` will produce a `tube:clay` dynamically typed `mark`
+conversion gate. The `path` specifies two `mark`s - _from_ and _to_, like
+`/txt/noun`.
 
 Example:
 
@@ -42,9 +181,12 @@ Example:
 [p=/text/plain q=[p=3 q=7.303.014]]
 ```
 
-## %d - List desks.
+---
 
-A scry with a `care` of `%d` will return a `(set desk)` of the `desk`s that exist on your ship.
+## `%d` - List desks.
+
+A scry with a `care` of `%d` will return a `(set desk)` of the `desk`s that
+exist on your ship.
 
 Example:
 
@@ -53,9 +195,14 @@ Example:
 {%bitcoin %base %landscape %webterm %garden %kids}
 ```
 
-## %e - Static mark core.
+---
 
-A scry with a `care` of `%e` will return a statically typed `nave:clay` `mark` core. The `path` in the scry specifies the `mark`. The type returned is a `(nave:clay {type} {diff})`, where `{type}` is the type the `mark` takes and `{diff}` is the type taken by the `mark` specified in `+form:grad`.
+## `%e` - Static mark core.
+
+A scry with a `care` of `%e` will return a statically typed `nave:clay` `mark`
+core. The `path` in the scry specifies the `mark`. The type returned is a
+`(nave:clay [type] [diff])`, where `[type]` is the type the `mark` takes and
+`[diff]` is the type taken by the `mark` specified in `+form:grad`.
 
 Example:
 
@@ -63,9 +210,12 @@ Example:
 .^((nave:clay noun noun) %ce %/noun)
 ```
 
-## %f - Stat. mark convert.
+---
 
-A scry with a `care` of `%f` will return a static `mark` conversion gate. The `path` specifies two `mark`s - _from_ and _to_, like `/txt/mime`.
+## `%f` - Stat. mark convert.
+
+A scry with a `care` of `%f` will return a static `mark` conversion gate. The
+`path` specifies two `mark`s - _from_ and _to_, like `/txt/mime`.
 
 ```
 > =a .^($-(text mime) %cf %/txt/mime)
@@ -73,11 +223,19 @@ A scry with a `care` of `%f` will return a static `mark` conversion gate. The `p
 [p=/text/plain q=[p=3 q=7.303.014]]
 ```
 
-## %p - File permissions.
+---
 
-A scry with a `care` of `%p` will return the permissions of the file or directory in question. The type returned is a `[dict:clay dict:clay]` where the head is read permissions and the tail is write permissions.
+## `%p` - File permissions.
 
-If the specified file or directory has no permissions set, it will default to the permissions of its parent. If nothing above it has permissions set, it will default to empty whitelists. If the specified file or directory doesn't exist, it will also return the default empty whitelist.
+A scry with a `care` of `%p` will return the permissions of the file or
+directory in question. The type returned is a [`[dict:clay
+dict:clay]`](/reference/arvo/clay/data-types#dictclay) where the head is read
+permissions and the tail is write permissions.
+
+If the specified file or directory has no permissions set, it will default to
+the permissions of its parent. If nothing above it has permissions set, it will
+default to empty whitelists. If the specified file or directory doesn't exist,
+it will also return the default empty whitelist.
 
 Example:
 
@@ -86,9 +244,13 @@ Example:
 [[src=/ rul=[mod=%white who=[p={} q={}]]] src=/ rul=[mod=%white who=[p={} q={}]]]
 ```
 
-## %r - File as vase.
+---
 
-A scry with a `care` of `%r` will return the data of the given file wrapped in a `vase` or crash if it's a directory. It's basically just a vase-wrapped `%x` scry.
+## `%r` - File as vase.
+
+A scry with a `care` of `%r` will return the data of the given file wrapped in a
+`vase` or crash if it's a directory. It's basically just a vase-wrapped `%x`
+scry.
 
 Examples:
 
@@ -110,19 +272,28 @@ Examples:
 Crash!
 ```
 
-## %s - Misc. scries.
+---
 
-A scry with a `care` of `%s` is for miscellaneous internal and debug functions and is liable to change in the future.
+## `%s` - Misc. scries.
 
-Rather than just a `path` to a file, the head of the `path` is tagged with one of `%yaki %blob %hash %cage %open %late %base` and the tail depends on which tag you use. We'll look at each in turn.
+A scry with a `care` of `%s` is for miscellaneous internal and debug functions
+and is liable to change in the future.
 
-### %yaki - Commit.
+Rather than just a `path` to a file, the head of the `path` is tagged with one
+of `%yaki %blob %hash %cage %open %late %base` and the tail depends on which tag
+you use. We'll look at each in turn.
 
-This will return the [yaki:clay](/reference/arvo/clay/data-types#yaki-clay-commit) of the specified commit. It takes a [tako:clay](/reference/arvo/clay/data-types#tako-clay-commit-reference).
+### `%yaki` - Commit.
+
+This will return the [yaki:clay](/reference/arvo/clay/data-types#yakiclay) of
+the specified commit. It takes a
+[tako:clay](/reference/arvo/clay/data-types#takoclay).
 
 Example:
 
-Here we scry the [dome:clay](/reference/arvo/clay/data-types#dome-desk-data) for `%`, get the latest `tako:clay` and the do a `%s` scry for the `yaki:clay` in question.
+Here we scry the [dome:clay](/reference/arvo/clay/data-types#domeclay) for `%`,
+get the latest `tako:clay` and the do a `%s` scry for the `yaki:clay` in
+question.
 
 ```
 > =/  =dome:clay  .^(dome:clay %cv %)
@@ -141,36 +312,42 @@ Here we scry the [dome:clay](/reference/arvo/clay/data-types#dome-desk-data) for
 ]
 ```
 
-### %blob - File blob.
+---
 
-This will return the [blob:clay](/reference/arvo/clay/data-types#blob-clay-data) of some file. It takes a [lobe:clay](/reference/arvo/clay/data-types#lobe-clay-data-reference).
+### `%blob` - File blob.
+
+This will return the [page:clay](/reference/arvo/clay/data-types#pageclay) of
+some file. It takes a [lobe:clay](/reference/arvo/clay/data-types#lobeclay).
 
 Example:
 
-Here we grab the `lobe:clay` of `/gen/hood/hi/hoon` with a `%y` scry, then use it to do a `%s` scry for the `blob:clay` of the file.
+Here we grab the `lobe:clay` of `/gen/hood/hi/hoon` with a `%y` scry, then use
+it to do a `%s` scry for the `blob:clay` of the file.
 
 ```
 > =/  =arch  .^(arch %cy %/gen/hood/hi/hoon)
   ?~  fil.arch
     ~
-  .^(blob:clay %cs %/blob/(scot %uv u.fil.arch))
-[ %direct
-  p=0vp.k7nsm.qkdr3.t17rp.33bae.8gajg.v27gi.40itr.2u9qa.nppbt.7k255
+  .^(page:clay %cs %/blob/(scot %uv u.fil.arch))
+[ p=%hoon
     q
-  [ p=%hoon
-      q
-3.548.750.706.400.251.607.252.023.288.575.526.190.856.734.474.077.821.289.791.377.301.707.878.697.553.411.219.689.905.949.957.893.633.811.025.757.107.990.477.902.858.170.125.439.223.250.551.937.540.468.638.902.955.378.837.954.792.031.592.462.617.422.136.386.332.469.076.584.061.249.923.938.374.214.925.312.954.606.277.212.923.859.309.330.556.730.410.200.952.056.760.727.611.447.500.996.168.035.027.753.417.869.213.425.113.257.514.474.700.810.203.348.784.547.006.707.150.406.298.809.062.567.217.447.347.357.039.994.339.342.906
-  ]
+  3.548.750.706.400.251.607.252.023.288.575.526.190.856.734.474.077.821.289.791.377.301.707.878.697.553.411.219.689.905.949.957.893.633.811.025.757.107.990.477.902.858.170.125.439.223.250.551.937.540.468.638.902.955.378.837.954.792.031.592.462.617.422.136.386.332.469.076.584.061.249.923.938.374.214.925.312.954.606.277.212.923.859.309.330.556.730.410.200.952.056.760.727.611.447.500.996.168.035.027.753.417.869.213.425.113.257.514.474.700.810.203.348.784.547.006.707.150.406.298.809.062.567.217.447.347.357.039.994.339.342.906
 ]
 ```
 
-### %hash - Commit hash.
+---
 
-This will return the `@uvI` content hash of the specified commit. It takes a `tako:clay`.
+### `%hash` - Commit hash.
+
+This will return the `@uvI` content hash of the specified commit. It takes a
+[`tako:clay`](/reference/arvo/clay/data-types#takoclay).
 
 Example:
 
-Here we grab the `dome:clay` for `%` with a `%v` scry, get the latest `tako:clay` and then do a `%s` `%hash` scry for it.
+Here we grab the [`dome:clay`](/reference/arvo/clay/data-types#domeclay) for `%`
+with a `%v` scry, get the latest
+[`tako:clay`](/reference/arvo/clay/data-types#takoclay) and then do a `%s`
+`%hash` scry for it.
 
 ```
 > =/  =dome:clay  .^(dome:clay %cv %)
@@ -179,7 +356,9 @@ Here we grab the `dome:clay` for `%` with a `%v` scry, get the latest `tako:clay
 0v16.er7uq.oke4u.cru7u.nglu9.q3su7.6ub1o.bh4qk.r5uav.ut12d.5rdl5
 ```
 
-### %cage - File as cage.
+---
+
+### `%cage` - File as cage.
 
 This will return a `cage` of the data of some file. It takes a `lobe:clay`.
 
@@ -201,13 +380,25 @@ Here we grab the `lobe:clay` of `/gen/hood/hi/hoon` with a `%y` scry, then use i
 ]
 ```
 
-### %open - Build prelude.
+---
 
-This is like a `%a` scry but it only compiles the prelude to the file, e.g. the Ford rune imports. Proper documentation for this will be done as part of Ford documentaton at a later date.
+### `%open` - Build prelude.
 
-### %late - Latest case.
+This is like a `%a` scry but it only compiles the prelude to the file, e.g. the
+Ford rune imports. Proper documentation for this will be done as part of Ford
+documentaton at a later date.
 
-This will return the most recent revision number of a `desk` that has been fully downloaded. The type it returns is a `cass:clay`. The `case` in the `beak` must be a revision number rather than a date. You can just provide a case of `1` since it returns the latest regardless. If we have nothing for the specified `desk`, this will just return the bunt of a `cass:clay` like `cass=[ud=0 da=~2000.1.1]`.
+---
+
+### `%late` - Latest case.
+
+This will return the most recent revision number of a `desk` that has been fully
+downloaded. The type it returns is a
+[`cass:clay`](/reference/arvo/clay/data-types#cassclay). The `case` in the
+`beak` must be a revision number rather than a date. You can just provide a case
+of `1` since it returns the latest regardless. If we have nothing for the
+specified `desk`, this will just return the bunt of a `cass:clay` like
+`cass=[ud=0 da=~2000.1.1]`.
 
 Example:
 
@@ -221,9 +412,15 @@ cass=[ud=50 da=~2021.4.22..10.38.50..57a8]
 cass=[ud=0 da=~2000.1.1]
 ```
 
-### %base - Merge-base.
+---
 
-This will return the mergebase (i.e. most recent common ancestor) between two `desk`s. The type it returns is a `(list tako:clay)`. The first `desk` will just be the one in the `beak` `path` prefix and the second will be specified like `/ship/desk` at the end of the scry `path`. If there is no common ancestor between the two `desk`s, this will just produce an empty `list`.
+### `%base` - Merge-base.
+
+This will return the mergebase (i.e. most recent common ancestor) between two
+`desk`s. The type it returns is a `(list tako:clay)`. The first `desk` will just
+be the one in the `beak` `path` prefix and the second will be specified like
+`/ship/desk` at the end of the scry `path`. If there is no common ancestor
+between the two `desk`s, this will just produce an empty `list`.
 
 Examples:
 
@@ -237,9 +434,15 @@ Examples:
 ~
 ```
 
-## %t - List files.
+---
 
-A scry with a `care` of `%t` will return a `(list path)` of all files in the given directory, or just a `(list path)` of the single file if it's a file. This is done recursively so will provide files in subdirectories as well. The paths will be fully qualified except for the `ship`, `desk` and `case`. If the directory or file specified does not exist, it will return an empty `list`.
+## `%t` - List files.
+
+A scry with a `care` of `%t` will return a `(list path)` of all files in the
+given directory, or just a `(list path)` of the single file if it's a file. This
+is done recursively so will provide files in subdirectories as well. The paths
+will be fully qualified except for the `ship`, `desk` and `case`. If the
+directory or file specified does not exist, it will return an empty `list`.
 
 Examples:
 
@@ -265,9 +468,13 @@ Examples:
 ~
 ```
 
-## %u - Check exists.
+---
 
-A scry with a `care` of `%u` will return a `?` depending on whether the file exists. It will produce `%.n` if it's a directory or doesn't exist and will produce `%.y` if it's a file and exists.
+## `%u` - Check exists.
+
+A scry with a `care` of `%u` will return a `?` depending on whether the file
+exists. It will produce `%.n` if it's a directory or doesn't exist and will
+produce `%.y` if it's a file and exists.
 
 Examples:
 
@@ -286,9 +493,12 @@ Examples:
 %.n
 ```
 
-## %v - Desk state.
+---
 
-A scry with a care of `%v` will return the entire state of a `desk` as a `dome:clay`.
+## `%v` - Desk state.
+
+A scry with a care of `%v` will return the entire state of a `desk` as a
+[`dome:clay`](/reference/arvo/clay/data-types#domeclay).
 
 Example:
 
@@ -300,9 +510,14 @@ Example:
 
 Note: If you try printing this it will take forever and probably OOM your ship.
 
-## %w - Revision number.
+---
 
-A scry with a `care` of `%w` will return the revision number and date of a given `case`. The type returned is a `cass:clay` like `[ud=@ud da=@da]` where `ud` is the revision number and `da` is the date.
+## `%w` - Revision number.
+
+A scry with a `care` of `%w` will return the revision number and date of a given
+`case`. The type returned is a
+[`cass:clay`](/reference/arvo/clay/data-types#cassclay) like `[ud=@ud da=@da]`
+where `ud` is the revision number and `da` is the date.
 
 Example:
 
@@ -311,9 +526,12 @@ Example:
 [ud=2 da=~2021.4.13..19.12.49..3389]
 ```
 
-## %x - Read file.
+---
 
-A scry with a `care` of `%x` will return the raw data of a file as an `@` or crash if it's a directory.
+## `%x` - Read file.
+
+A scry with a `care` of `%x` will return the raw data of a file as an `@` or
+crash if it's a directory.
 
 Examples:
 
@@ -332,11 +550,16 @@ Examples:
 Crash!
 ```
 
-## %y - Read arch.
+---
+
+## `%y` - Read arch.
 
 A scry with a `care` of `%y` will return the `arch` of a file or directory.
 
-An `arch` is a `[fil=(unit lobe:clay) dir=(map @ta ~)]`. The `fil` will contain the `lobe:clay` hash if it's a file, otherwise it will be null. The `dir` will contain a map of the files and directories it contains, otherwise it will be null.
+An `arch` is a `[fil=(unit lobe:clay) dir=(map @ta ~)]`. The `fil` will contain
+the [`lobe:clay`](/reference/arvo/clay/data-types#lobeclay) hash if it's a file,
+otherwise it will be null. The `dir` will contain a map of the files and
+directories it contains, otherwise it will be null.
 
 It will return the bunt of an `arch` if the file or directory is not found.
 
@@ -373,9 +596,13 @@ Examples:
 [fil=~ dir={}]
 ```
 
-## %z - Content hash.
+---
 
-A scry with a `care` of `%z` will return the hash of a file or the recursive hash of a directory. If the file or directory doesn't exist it will return a null value.
+## `%z` - Content hash.
+
+A scry with a `care` of `%z` will return the hash of a file or the recursive
+hash of a directory. If the file or directory doesn't exist it will return a
+null value.
 
 The type returned is a `@uxI`.
 
@@ -395,3 +622,5 @@ Examples:
 > .^(@uvI %cz %/foobar)
 0v0
 ```
+
+---

--- a/content/reference/arvo/clay/scry.md
+++ b/content/reference/arvo/clay/scry.md
@@ -156,7 +156,7 @@ Example:
 
 ---
 
-## `%b` - Dyn. mark core.
+## `%b` - Dyn. mark core
 
 A scry with a `care` of `%b` will produce a `dais:clay` processed `mark` core
 for the specified `mark`. The `path` in the scry is a `mark`.
@@ -167,7 +167,7 @@ Example:
 .^(dais:clay %cb %/txt)
 ```
 
-## %c - Dyn. mark convert.
+## %c - Dyn. mark convert
 
 A scry with a `care` of `%c` will produce a `tube:clay` dynamically typed `mark`
 conversion gate. The `path` specifies two `mark`s - _from_ and _to_, like
@@ -183,7 +183,7 @@ Example:
 
 ---
 
-## `%d` - List desks.
+## `%d` - List desks
 
 A scry with a `care` of `%d` will return a `(set desk)` of the `desk`s that
 exist on your ship.
@@ -197,7 +197,7 @@ Example:
 
 ---
 
-## `%e` - Static mark core.
+## `%e` - Static mark core
 
 A scry with a `care` of `%e` will return a statically typed `nave:clay` `mark`
 core. The `path` in the scry specifies the `mark`. The type returned is a
@@ -212,7 +212,7 @@ Example:
 
 ---
 
-## `%f` - Stat. mark convert.
+## `%f` - Stat. mark convert
 
 A scry with a `care` of `%f` will return a static `mark` conversion gate. The
 `path` specifies two `mark`s - _from_ and _to_, like `/txt/mime`.
@@ -225,7 +225,7 @@ A scry with a `care` of `%f` will return a static `mark` conversion gate. The
 
 ---
 
-## `%p` - File permissions.
+## `%p` - File permissions
 
 A scry with a `care` of `%p` will return the permissions of the file or
 directory in question. The type returned is a [`[dict:clay
@@ -246,7 +246,7 @@ Example:
 
 ---
 
-## `%r` - File as vase.
+## `%r` - File as vase
 
 A scry with a `care` of `%r` will return the data of the given file wrapped in a
 `vase` or crash if it's a directory. It's basically just a vase-wrapped `%x`
@@ -274,7 +274,7 @@ Crash!
 
 ---
 
-## `%s` - Misc. scries.
+## `%s` - Misc. scries
 
 A scry with a `care` of `%s` is for miscellaneous internal and debug functions
 and is liable to change in the future.
@@ -283,7 +283,7 @@ Rather than just a `path` to a file, the head of the `path` is tagged with one
 of `%yaki %blob %hash %cage %open %late %base` and the tail depends on which tag
 you use. We'll look at each in turn.
 
-### `%yaki` - Commit.
+### `%yaki` - Commit
 
 This will return the [yaki:clay](/reference/arvo/clay/data-types#yakiclay) of
 the specified commit. It takes a
@@ -314,7 +314,7 @@ question.
 
 ---
 
-### `%blob` - File blob.
+### `%blob` - File blob
 
 This will return the [page:clay](/reference/arvo/clay/data-types#pageclay) of
 some file. It takes a [lobe:clay](/reference/arvo/clay/data-types#lobeclay).
@@ -337,7 +337,7 @@ it to do a `%s` scry for the `blob:clay` of the file.
 
 ---
 
-### `%hash` - Commit hash.
+### `%hash` - Commit hash
 
 This will return the `@uvI` content hash of the specified commit. It takes a
 [`tako:clay`](/reference/arvo/clay/data-types#takoclay).
@@ -358,7 +358,7 @@ with a `%v` scry, get the latest
 
 ---
 
-### `%cage` - File as cage.
+### `%cage` - File as cage
 
 This will return a `cage` of the data of some file. It takes a `lobe:clay`.
 
@@ -382,7 +382,7 @@ Here we grab the `lobe:clay` of `/gen/hood/hi/hoon` with a `%y` scry, then use i
 
 ---
 
-### `%open` - Build prelude.
+### `%open` - Build prelude
 
 This is like a `%a` scry but it only compiles the prelude to the file, e.g. the
 Ford rune imports. Proper documentation for this will be done as part of Ford
@@ -390,7 +390,7 @@ documentaton at a later date.
 
 ---
 
-### `%late` - Latest case.
+### `%late` - Latest case
 
 This will return the most recent revision number of a `desk` that has been fully
 downloaded. The type it returns is a
@@ -414,7 +414,7 @@ cass=[ud=0 da=~2000.1.1]
 
 ---
 
-### `%base` - Merge-base.
+### `%base` - Merge-base
 
 This will return the mergebase (i.e. most recent common ancestor) between two
 `desk`s. The type it returns is a `(list tako:clay)`. The first `desk` will just
@@ -436,7 +436,7 @@ Examples:
 
 ---
 
-## `%t` - List files.
+## `%t` - List files
 
 A scry with a `care` of `%t` will return a `(list path)` of all files in the
 given directory, or just a `(list path)` of the single file if it's a file. This
@@ -470,7 +470,7 @@ Examples:
 
 ---
 
-## `%u` - Check exists.
+## `%u` - Check exists
 
 A scry with a `care` of `%u` will return a `?` depending on whether the file
 exists. It will produce `%.n` if it's a directory or doesn't exist and will
@@ -495,7 +495,7 @@ Examples:
 
 ---
 
-## `%v` - Desk state.
+## `%v` - Desk state
 
 A scry with a care of `%v` will return the entire state of a `desk` as a
 [`dome:clay`](/reference/arvo/clay/data-types#domeclay).
@@ -512,7 +512,7 @@ Note: If you try printing this it will take forever and probably OOM your ship.
 
 ---
 
-## `%w` - Revision number.
+## `%w` - Revision number
 
 A scry with a `care` of `%w` will return the revision number and date of a given
 `case`. The type returned is a
@@ -528,7 +528,7 @@ Example:
 
 ---
 
-## `%x` - Read file.
+## `%x` - Read file
 
 A scry with a `care` of `%x` will return the raw data of a file as an `@` or
 crash if it's a directory.
@@ -552,7 +552,7 @@ Crash!
 
 ---
 
-## `%y` - Read arch.
+## `%y` - Read arch
 
 A scry with a `care` of `%y` will return the `arch` of a file or directory.
 
@@ -598,7 +598,7 @@ Examples:
 
 ---
 
-## `%z` - Content hash.
+## `%z` - Content hash
 
 A scry with a `care` of `%z` will return the hash of a file or the recursive
 hash of a directory. If the file or directory doesn't exist it will return a


### PR DESCRIPTION
- add new tasks tombstoning & app management tasks
- documented previously undocumented scry endpoints
- update & rejigger data types reference