### PR TITLE
Update binary links to pull from new runtime repo

### DIFF
--- a/content/guides/quickstart/chat-guide.md
+++ b/content/guides/quickstart/chat-guide.md
@@ -53,13 +53,13 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g' 
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/' 
 ```
 
 #### macOS (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/chat-guide.md
+++ b/content/guides/quickstart/chat-guide.md
@@ -38,28 +38,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux (`aarch64`)
-
-```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
-```
-
 #### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
-#### macOS (`aarch64`)
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g' 
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/chat-guide.md
+++ b/content/guides/quickstart/chat-guide.md
@@ -38,16 +38,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
 ```
 
-#### Mac
+#### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+```
+
+#### macOS (`x86_64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
 ```
 
 ## Development ship

--- a/content/guides/quickstart/groups-guide.md
+++ b/content/guides/quickstart/groups-guide.md
@@ -42,28 +42,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux (`aarch64`)
-
-```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
-```
-
 #### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
-#### macOS (`aarch64`)
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g'
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/groups-guide.md
+++ b/content/guides/quickstart/groups-guide.md
@@ -42,16 +42,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
 ```
 
-#### Mac
+#### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+```
+
+#### macOS (`x86_64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
 ```
 
 ## Development ship

--- a/content/guides/quickstart/groups-guide.md
+++ b/content/guides/quickstart/groups-guide.md
@@ -57,13 +57,13 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g'
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/'
 ```
 
 #### macOS (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/voting-guide.md
+++ b/content/guides/quickstart/voting-guide.md
@@ -60,13 +60,13 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g'
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/'
 ```
 
 #### macOS (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/voting-guide.md
+++ b/content/guides/quickstart/voting-guide.md
@@ -45,28 +45,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux (`aarch64`)
-
-```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
-```
-
 #### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
-#### macOS (`aarch64`)
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --transform='s/.*/urbit/g'
 ```
 
 #### macOS (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk -s '/.*/urbit/g'
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk -s '/.*/urbit/g'
 ```
 
 ## Development ship

--- a/content/guides/quickstart/voting-guide.md
+++ b/content/guides/quickstart/voting-guide.md
@@ -45,16 +45,28 @@ If you've already got the `urbit` CLI runtime installed, you can skip this step.
 Otherwise, run one of the commands below, depending on your platform. It will
 fetch the binary and save it in the current directory.
 
-#### Linux
+#### Linux (`aarch64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1
 ```
 
-#### Mac
+#### Linux (`x86_64`)
 
 ```shell {% copy=true %}
-curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1
+```
+
+#### macOS (`aarch64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1
+```
+
+#### macOS (`x86_64`)
+
+```shell {% copy=true %}
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1
 ```
 
 ## Development ship


### PR DESCRIPTION
WIP until final filenames/URLs are confirmed.

See https://github.com/urbit/urbit.org/pull/1943 for similar `urbit.org` changes.