### PR TITLE
Fix anchor links

### DIFF
--- a/lib/buildGlossary.js
+++ b/lib/buildGlossary.js
@@ -28,7 +28,7 @@ function buildGlossary(dir) {
                         url: "https://developers.urbit.org" + path.join(
                             dir.substr(dir.indexOf("content") + 7),
                             "/",
-                            page.name.replace(/.md$/, "")
+                            [page.name.replace(/.md$/, ""), e.slug].join('')
                         )
                     }
                 }))


### PR DESCRIPTION
Resolves #289 

The issue started when [**this**](https://github.com/urbit/foundation-design-system/blob/c8d953a852b044fd6e4dd6dc8c478609412bc76e/src/components/ui/Search/Search.js#L57) line in the design system was changed to [**this**](https://github.com/urbit/foundation-design-system/blob/8a448320003c2c9254481fc0b2cefaf2be3b324b/src/components/ui/Search/Search.js#L49).

You don't have this issue on the others websites probably because they are using an older version (0.7.1) of the design system.