### PR TITLE
Correct discussion and example of `tishep`

### DIFF
--- a/content/reference/hoon/rune/tis.md
+++ b/content/reference/hoon/rune/tis.md
@@ -533,18 +533,22 @@ Two arguments, fixed.
 #### Discussion
 
 `=-` is just like `=+` but its subexpressions are reversed. `=-` looks better
-than `=+` when the expression you're pinning to the subject is much smaller than
+than `=+` when the expression you're pinning to the subject is much larger than
 the expression that uses it.
 
 #### Examples
 
 ```
 > =foo |=  a=@
-       =+  b=1
-       =-  (add a b c)
-       c=2
+       =-  (add a b)
+       :*  %a-bunch
+           %of-stuff
+           %here
+           b=2
+           %and-perhaps-more
+       ==
 > (foo 5)
-8
+7
 ```
 
 ---


### PR DESCRIPTION
The existing example doesn't compile because it contains

    (add a b c)

There's a chance that I'm the one that wrote the broken example back in like 2017 but anyway, the example provided in this commit 1) compiles and 2) illustrates why we have these kinds of "inverted" runes.

The discussion also needed a fix:

> `=-` is just like `=+` but its subexpressions are reversed. `=-` looks
> better than `=+` when the expression you're pinning to the subject is much
> *larger* than the expression that uses it.

Resolves #317.