### PR TITLE
Correct signed/unsigned for parameters in stdlib 3b

### DIFF
--- a/content/reference/hoon/stdlib/3b.md
+++ b/content/reference/hoon/stdlib/3b.md
@@ -2739,7 +2739,7 @@ An `fn`.
 
 ### `++sun:fl`
 
-Signed integer to float
+Unsigned integer to float
 
 Produces `a` in floating-point representation.
 
@@ -2778,11 +2778,11 @@ An `fn`.
 
 Signed integer to float
 
-Produces the floating-point representation of `a`, an unsigned integer.
+Produces the floating-point representation of `a`, a signed integer.
 
 #### Accepts
 
-`a` is an unsigned integer.
+`a` is a signed integer.
 
 #### Produces
 
@@ -3869,7 +3869,7 @@ Converts `a` from a signed integer to `@r`.
 
 #### Accepts
 
-`a` is `@s`, an unsigned integer
+`a` is `@s`, a signed integer
 
 #### Produces
 
@@ -5461,9 +5461,9 @@ A `@rs`.
 
 ### `++san:rs`
 
-Signed integer to `@rs`'
+Signed integer to `@rs`
 
-Converts `a` from an unsigned integer to `@rs`.
+Converts `a` from a signed integer to `@rs`.
 
 #### Accepts
 
@@ -6138,7 +6138,7 @@ A `@rq`.
 
 Unsigned integer to `@rq`
 
-Converts `@` from an unsigned integer to `@rq`.
+Converts `a` from an unsigned integer to `@rq`.
 
 #### Accepts
 
@@ -6167,7 +6167,7 @@ A `@rq`, a quad-precision float.
 
 Signed integer to `rq`
 
-Converts `@` from a signed integer to `@rq`.
+Converts `a` from a signed integer to `@rq`.
 
 #### Accepts
 
@@ -6907,7 +6907,7 @@ A `@rh`, a half-precision float.
 
 Unsigned integer to `@rh`
 
-Converts `@` from an unsigned integer to `@rh`.
+Converts `a` from an unsigned integer to `@rh`.
 
 #### Accepts
 
@@ -6936,7 +6936,7 @@ A `@rh`, a half-precision float.
 
 Signed integer to `@rh`
 
-Converts `@` from a signed integer to `@rh`.
+Converts `a` from a signed integer to `@rh`.
 
 #### Accepts
 


### PR DESCRIPTION
I also noticed that
```
> (san:rs -343)
.-343
```
while the doc says
```
> (san:rs -343)
.-3.43e2'
```
There are probably others but I didn't change these in this PR.

I also noticed `++toi:rs` "Rounds `a` to the nearest integer." but really produces the `floor`, or nearest integer towards `0`.
```
> (toi:rs .2.2)
[~ --2]
> (toi:rs .2.8)
[~ --2]
> (toi:rs .-2.8)
[~ -2]
> (toi:rs .-2.2)
[~ -2]
```
There are probably others but I didn't change these in this PR.
