### PR TITLE
eyre: fix %connections scry description typo

### DIFF
--- a/content/reference/arvo/eyre/scry.md
+++ b/content/reference/arvo/eyre/scry.md
@@ -133,7 +133,7 @@ A scry with `bindings` in place of the `desk` in the `beak` will return Eyre's U
 
 ## `%connections`
 
-A scry with `bindings` in place of the `desk` in the `beak` will return all open HTTP connections that aren't fully complete. The type returned is a `(map duct outstanding-connection:eyre)` (see the [$outstanding-connection](/reference/arvo/eyre/data-types#outstanding-connection) section of the Data Types document for details).
+A scry with `connections` in place of the `desk` in the `beak` will return all open HTTP connections that aren't fully complete. The type returned is a `(map duct outstanding-connection:eyre)` (see the [$outstanding-connection](/reference/arvo/eyre/data-types#outstanding-connection) section of the Data Types document for details).
 
 ### Example {% #example-6 %}
 


### PR DESCRIPTION
Looks like `bindings` was incorrectly copy-pasted from the previous `%bindings` section.