### PR TITLE
Typos

### DIFF
--- a/content/guides/quickstart/voting-guide.md
+++ b/content/guides/quickstart/voting-guide.md
@@ -1950,7 +1950,7 @@ our own instead. In the normal shell, do the following:
 
 ```shell {% copy=true %}
 rm -r dev-comet/tally/*
-cp -r tally/* dev-comet/tally/*
+cp -r tally/* dev-comet/tally/
 ```
 
 Back in the Dojo again, we can now commit those files and install the app:


### PR DESCRIPTION
Couple of typos that throw syntax errors. The guide otherwise works e2e except the app doesn't load:

<img width="477" alt="Screenshot 2023-07-12 at 10 13 35" src="https://github.com/urbit/developers.urbit.org/assets/8304391/ba59b59c-20de-4836-aebc-b32fd5daf833">

related to https://github.com/urbit/urbit/issues/1942 but clearly a different error