### PR TITLE
Update groups-guide.md: kelvin version 414->416

### DIFF
--- a/content/guides/quickstart/groups-guide.md
+++ b/content/guides/quickstart/groups-guide.md
@@ -1916,7 +1916,7 @@ this by adding a `sys.kelvin` file to the root of our `squad` directory:
 
 ```shell {% copy=true %}
 cd squad
-echo "[%zuse 414]" > sys.kelvin
+echo "[%zuse 416]" > sys.kelvin
 ```
 
 We also need to specify which agents to start when our desk is installed. We do


### PR DESCRIPTION
Error is thrown when following instructions faithfully. Changing the kelvin version to 416 fixes the error.