### PR TITLE
Typo in glossary title (Kelvin versioning -> Kernel)

### DIFF
--- a/content/reference/glossary/kernel.md
+++ b/content/reference/glossary/kernel.md
@@ -1,5 +1,5 @@
 +++
-title = "Kelvin versioning"
+title = "Kernel"
 
 [extra]
 category = "arvo"


### PR DESCRIPTION
The title of the Kernel page in the glossary is incorrectly labeled as "Kelvin versioning". This is probably a copy-paste error. This also means the Glossary sidebar has 2 entries named "Kelvin versioning".

This commit fixes this typo.